### PR TITLE
feat: Jira Cloud integration (v1.2.0)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,3 +51,7 @@ GOOGLE_CLIENT_SECRET=
 #   {TESTHUB_BASE_URL}/api/auth/oauth/github/callback
 # Google OAuth client Authorized redirect URI (Google Cloud Console):
 #   {TESTHUB_BASE_URL}/api/auth/oauth/google/callback
+
+# Auto-sync all Jira integrations every N minutes (0 = disabled).
+# Needs outbound reachability to Jira Cloud; no public endpoint required.
+JIRA_AUTOSYNC_MINUTES=0

--- a/PHASE2_JIRA.md
+++ b/PHASE2_JIRA.md
@@ -1,0 +1,86 @@
+# Phase 2 — Jira integration (v1.2.0)
+
+Branch: `feat/jira-integration`
+Goal: two-way link between ThoroTest and Jira Cloud, reusing the `external_*` fields
+shipped in v1.1 on both Requirement and Defect. No schema change needed.
+
+Two flows, one `jira` integration config:
+1. **Pull** Jira stories/epics → requirements (inbound; Jira is source of truth for these)
+2. **Push** ThoroTest defects → Jira bugs (outbound; ThoroTest creates, Jira tracks)
+
+## 1. Integration config (`type = "jira"`)
+
+`config = { base_url, email, api_token, project_key, issue_type_bug, issue_type_story }`
+
+- Auth: HTTP Basic `email:api_token` (Jira Cloud REST v3).
+- `api_token` redaction reuses the existing merge-safe path in `integrations.py`
+  (`token_set` pattern) — rename-agnostic; store under `api_token`, never return it.
+
+## 2. `backend/jira_sync.py` (templated on `github_sync.py`)
+
+`JiraClient(base_url, email, api_token)`:
+- `_request()` wrapper with clear RuntimeError messages per status (401/403/404/rate-limit)
+- `create_issue(project_key, issue_type, summary, description) -> {key, url}`
+  (`POST /rest/api/3/issue`; description as ADF or plain text)
+- `get_issue(key) -> {status, summary, type}` (`GET /rest/api/3/issue/{key}`)
+- `search_issues(jql) -> [issues]` (`GET /rest/api/3/search`, paginated)
+
+`sync_jira_requirements(db, integration) -> stats`:
+- JQL: `project = {key} AND issuetype in (Story, Epic)`
+- Upsert requirements matched by `external_key`; map Jira status → requirement status,
+  issuetype → type (epic/story/feature). Preserve local test links.
+
+`push_defect_to_jira(db, integration, defect) -> defect`:
+- Create bug issue from defect (title→summary, description, severity→priority map)
+- Store `external_provider="jira"`, `external_key`, `external_url` on the defect.
+
+## 3. Router wiring
+
+- `integrations.py` sync endpoint: branch on `integration.type` — `github` →
+  `github_sync.sync_integration`, `jira` → `jira_sync.sync_jira_requirements`.
+- `defects.py`: `POST /api/defects/{id}/push` (admin/manager) — pick the jira
+  integration, call `push_defect_to_jira`, return updated defect. 409 if already pushed.
+
+## 4. Schemas
+
+- `DefectOut` gains `external_provider/key/url` (already columns; add to schema + initial-data).
+- Requirement already exposes external fields.
+
+## 5. Frontend
+
+- **Settings → Integrations**: Jira add/edit form (base_url, email, api_token,
+  project_key, issue types). Sync button already generic.
+- **Defects view + test-detail Defects tab**: "Push to Jira" action per defect; show
+  `external_key` as a link once pushed.
+- **Requirements view**: already renders `external_key` link — verify Jira-sourced ones.
+- api.js: `pushDefectToJira(id)`.
+
+## 6. Tests
+
+- pytest `test_jira_sync.py`: mock httpx — client request/error mapping, requirement
+  upsert by external_key + status mapping, defect push stores external fields + 409 on
+  re-push, config validation. No real network.
+- e2e: Jira integration form renders + validation (no live Jira; API mocked or skipped).
+
+## 7. Docs + version
+
+- README Jira section (setup, JQL, field mapping, security note on api_token storage).
+- In-app docs integrations note.
+- PRODUCTION_ROADMAP: mark 1.2 done.
+- Bump `package.json` 1.1.0 → 1.2.0.
+
+## Commit sequence
+
+1. jira_sync.py + DefectOut external fields + initial-data
+2. router wiring (sync branch + defect push) + schemas
+3. frontend (integration form + push action + api.js)
+4. pytest + e2e
+5. docs + version bump
+
+## Security notes
+
+- `api_token` is a secret — stored in integration config, never returned to clients
+  (only `token_set: true`), same as the GitHub PAT.
+- Outbound push publishes defect title/description to Jira — confirm the target
+  integration before first push; the push endpoint is admin/manager only.
+- Restrict `base_url` to https; validate it's a well-formed Atlassian host.

--- a/PRODUCTION_ROADMAP.md
+++ b/PRODUCTION_ROADMAP.md
@@ -20,7 +20,7 @@ not yet sellable production. Items ordered by priority — work top to bottom.
 | Version | Feature | Status |
 |---|---|---|
 | 1.1 | Requirements & test coverage (features/stories/epics ↔ tests, coverage metrics, YAML/JSON/CSV import, GraphQL) | ✅ Done — `feat/requirements-coverage` |
-| 1.2 | Jira integration (pull stories → requirements, push defects → bugs) — reuses `external_*` fields shipped in 1.1 | ⏳ Next |
+| 1.2 | Jira integration (pull stories → requirements, push defects → bugs) — reuses `external_*` fields shipped in 1.1 | ✅ Done — `feat/jira-integration` |
 
 ## Item detail
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ cp .env.example .env
 | `AI_API_KEY` | _(unset)_ | API key for the OpenAI-compatible endpoint (any value for local servers) |
 | `GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET` | _(unset)_ | GitHub OAuth login (optional) |
 | `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` | _(unset)_ | Google OAuth login (optional) |
+| `JIRA_AUTOSYNC_MINUTES` | `0` | Auto-sync all Jira integrations every N minutes (`0` = disabled). Requires outbound reachability to Jira Cloud |
 
 Database URLs:
 
@@ -184,6 +185,12 @@ Two-way link with Jira Cloud, sharing one `jira` integration
 
 Both reuse the `external_provider` / `external_key` / `external_url` fields shipped in
 v1.1 on Requirement and Defect — no schema change.
+
+**Auto-sync (optional):** set `JIRA_AUTOSYNC_MINUTES` > 0 to have the backend pull every
+Jira integration on that interval — no manual Sync needed. Per-integration failures are
+logged and skipped, so one misconfigured integration can't stall the others. Off by
+default (`0`); needs outbound reachability to Jira Cloud (works self-hosted, no public
+endpoint required, unlike an inbound webhook).
 
 **Security:** `api_token` is stored in the integration config and **never returned to
 clients** — the API reports only `api_token_set: true`, and a blank value on edit keeps

--- a/README.md
+++ b/README.md
@@ -168,6 +168,30 @@ Only `title` is required. Malformed files are skipped and reported in the sync r
 
 ---
 
+## Jira integration
+
+Two-way link with Jira Cloud, sharing one `jira` integration
+(**Settings → Integrations → Add → Jira**). Config: `base_url`, `email`,
+`api_token`, `project_key`, and the bug issue type.
+
+- **Pull** (inbound): **Sync** runs a JQL query (`project = KEY AND issuetype in
+  (Story, Epic)`) and upserts matching issues as requirements — matched by
+  `external_key`, with Jira status/issuetype mapped to requirement status/type. Local
+  test links are preserved across re-syncs.
+- **Push** (outbound): on the Defects view, **Push to Jira** creates a bug from a defect
+  (`POST /api/defects/{id}/push`, admin/manager) and stores the issue key + URL on the
+  defect. Re-pushing a linked defect is rejected (409).
+
+Both reuse the `external_provider` / `external_key` / `external_url` fields shipped in
+v1.1 on Requirement and Defect — no schema change.
+
+**Security:** `api_token` is stored in the integration config and **never returned to
+clients** — the API reports only `api_token_set: true`, and a blank value on edit keeps
+the stored secret (same handling as the GitHub PAT). `base_url` must be `https`. The push
+endpoint publishes the defect title/description to Jira and is admin/manager only.
+
+---
+
 ## Requirements & coverage
 
 Track features, stories, and epics as **requirements**, and link each to the tests that
@@ -254,6 +278,7 @@ thorotest/
 │   ├── emailer.py          # Outbound system email (password resets) via env SMTP
 │   ├── gql_schema.py       # Strawberry GraphQL schema
 │   ├── github_sync.py      # Tests-as-Code: read YAML tests from a GitHub repo
+│   ├── jira_sync.py        # Jira Cloud: pull stories→requirements, push defects→bugs
 │   └── routers/
 │       ├── _pagination.py  # Shared limit/offset + X-Total-Count helper
 │       ├── auth.py         # /auth/register, /auth/login, /me, /users, password reset
@@ -381,6 +406,7 @@ backend/tests/
 ├── test_test_detail_tabs.py  # History, defects, comments endpoints
 ├── test_defects.py           # Defects CRUD, filters, severity/status logic
 ├── test_requirements.py      # Requirements CRUD, coverage, linking, import, roles
+├── test_jira_sync.py         # Jira sync, defect push, config secret redaction
 ├── test_steps.py             # Structured test steps CRUD
 ├── test_step_execution.py    # Step execution and result recording
 ├── test_attachments.py       # File upload/download per test and run

--- a/backend/jira_sync.py
+++ b/backend/jira_sync.py
@@ -1,0 +1,246 @@
+"""Jira Cloud integration — two-way link with ThoroTest.
+
+Two flows, sharing one `jira` integration config:
+
+  * push_defect_to_jira()      ThoroTest defect  → Jira bug   (outbound)
+  * sync_jira_requirements()   Jira story/epic   → requirement (inbound, JQL poll)
+
+Both reuse the external_provider/external_key/external_url columns that exist on
+both Defect and Requirement. The HTTP layer (JiraClient) is kept separate from the
+DB logic so tests can inject a fake client without network access.
+
+Auth is HTTP Basic `email:api_token` (Jira Cloud REST v3). The api_token is stored
+in the integration config and never returned to clients.
+"""
+import re
+from datetime import datetime, timezone
+
+import httpx
+
+from . import models
+
+_ISSUE_TYPE_MAP = {
+    "epic": "epic",
+    "story": "story",
+    "task": "feature",
+    "sub-task": "feature",
+    "subtask": "feature",
+    "bug": "feature",
+}
+
+# Jira statusCategory.key → requirement status
+_STATUS_CATEGORY_MAP = {
+    "new": "active",
+    "indeterminate": "active",
+    "done": "done",
+}
+
+# ThoroTest severity → Jira priority name
+_SEVERITY_TO_PRIORITY = {
+    "critical": "Highest",
+    "high": "High",
+    "med": "Medium",
+    "low": "Low",
+}
+
+
+def normalize_base_url(base_url: str) -> str:
+    """Validate + normalize a Jira Cloud base URL. Raises ValueError."""
+    if not base_url:
+        raise ValueError("base_url is required")
+    url = base_url.strip().rstrip("/")
+    if not url.startswith("https://"):
+        raise ValueError("base_url must be https://")
+    if not re.match(r"^https://[A-Za-z0-9.-]+(\.atlassian\.net|\.jira\.com)$", url) \
+       and not re.match(r"^https://[A-Za-z0-9.-]+$", url):
+        raise ValueError(f"not a valid Jira base url: {base_url}")
+    return url
+
+
+def _adf(text: str) -> dict:
+    """Minimal Atlassian Document Format wrapper for a plain-text description (v3 API)."""
+    paragraphs = (text or "").split("\n")
+    content = []
+    for p in paragraphs:
+        node = {"type": "paragraph", "content": []}
+        if p:
+            node["content"].append({"type": "text", "text": p})
+        content.append(node)
+    return {"type": "doc", "version": 1, "content": content or [{"type": "paragraph", "content": []}]}
+
+
+class JiraClient:
+    """Thin Jira Cloud REST v3 wrapper. Raises RuntimeError on API errors."""
+
+    def __init__(self, base_url: str, email: str, api_token: str, timeout: float = 15.0):
+        self.base_url = normalize_base_url(base_url)
+        self._client = httpx.Client(
+            base_url=self.base_url,
+            auth=(email, api_token),
+            headers={"Accept": "application/json", "Content-Type": "application/json"},
+            timeout=timeout,
+        )
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self._client.close()
+
+    def _request(self, method: str, url: str, **kwargs):
+        try:
+            r = self._client.request(method, url, **kwargs)
+        except httpx.HTTPError as e:
+            raise RuntimeError(f"jira request failed: {e}")
+        if r.status_code == 404:
+            raise RuntimeError(f"jira 404: {url} (project/issue wrong or no access)")
+        if r.status_code in (401, 403):
+            raise RuntimeError(f"jira auth error ({r.status_code}): check email + api_token")
+        if r.status_code == 429:
+            raise RuntimeError("jira rate-limited (429) — retry later")
+        if r.status_code >= 400:
+            raise RuntimeError(f"jira error {r.status_code}: {r.text[:200]}")
+        return r
+
+    def create_issue(self, project_key: str, issue_type: str, summary: str, description: str = "") -> dict:
+        payload = {
+            "fields": {
+                "project": {"key": project_key},
+                "issuetype": {"name": issue_type},
+                "summary": summary[:255],
+                "description": _adf(description),
+            }
+        }
+        r = self._request("POST", "/rest/api/3/issue", json=payload)
+        key = r.json()["key"]
+        return {"key": key, "url": f"{self.base_url}/browse/{key}"}
+
+    def get_issue(self, key: str) -> dict:
+        r = self._request("GET", f"/rest/api/3/issue/{key}",
+                          params={"fields": "summary,status,issuetype"})
+        f = r.json().get("fields", {})
+        return {
+            "key": key,
+            "summary": f.get("summary", ""),
+            "status_category": (f.get("status", {}).get("statusCategory", {}) or {}).get("key", ""),
+            "issue_type": (f.get("issuetype", {}) or {}).get("name", ""),
+        }
+
+    def search_issues(self, jql: str, max_results: int = 100) -> list[dict]:
+        """Paginated JQL search. Returns normalized issue dicts."""
+        out: list[dict] = []
+        start = 0
+        while True:
+            r = self._request("GET", "/rest/api/3/search", params={
+                "jql": jql, "startAt": start, "maxResults": max_results,
+                "fields": "summary,status,issuetype,priority,assignee",
+            })
+            data = r.json()
+            for issue in data.get("issues", []):
+                f = issue.get("fields", {})
+                out.append({
+                    "key": issue["key"],
+                    "summary": f.get("summary", ""),
+                    "status_category": (f.get("status", {}).get("statusCategory", {}) or {}).get("key", ""),
+                    "issue_type": (f.get("issuetype", {}) or {}).get("name", ""),
+                    "assignee": (f.get("assignee") or {}).get("emailAddress"),
+                })
+            total = data.get("total", 0)
+            start += max_results
+            if start >= total or not data.get("issues"):
+                break
+        return out
+
+
+def _client_from_config(cfg: dict) -> JiraClient:
+    base_url = cfg.get("base_url")
+    email = cfg.get("email")
+    api_token = cfg.get("api_token")
+    if not (base_url and email and api_token):
+        raise ValueError("jira config requires base_url, email, and api_token")
+    return JiraClient(base_url, email, api_token)
+
+
+def push_defect_to_jira(db, integration, defect, client: JiraClient | None = None) -> models.Defect:
+    """Create a Jira bug from a defect and store the external link on it."""
+    if defect.external_key:
+        raise ValueError(f"defect {defect.id} already linked to {defect.external_key}")
+    cfg = integration.config or {}
+    project_key = cfg.get("project_key")
+    if not project_key:
+        raise ValueError("jira config missing 'project_key'")
+    issue_type = cfg.get("issue_type_bug") or "Bug"
+
+    own_client = client is None
+    client = client or _client_from_config(cfg)
+    try:
+        description = defect.description or ""
+        sev = (defect.severity or "med").lower()
+        if sev in _SEVERITY_TO_PRIORITY:
+            description = f"[severity: {sev}]\n\n{description}".strip()
+        result = client.create_issue(project_key, issue_type, defect.title or defect.id, description)
+    finally:
+        if own_client:
+            client._client.close()
+
+    defect.external_provider = "jira"
+    defect.external_key = result["key"]
+    defect.external_url = result["url"]
+    db.commit()
+    return defect
+
+
+def sync_jira_requirements(db, integration, client: JiraClient | None = None) -> dict:
+    """Pull Jira stories/epics into requirements (upsert by external_key)."""
+    cfg = integration.config or {}
+    project_key = cfg.get("project_key")
+    if not project_key:
+        raise ValueError("jira config missing 'project_key'")
+
+    own_client = client is None
+    client = client or _client_from_config(cfg)
+    try:
+        jql = cfg.get("jql") or f'project = "{project_key}" AND issuetype in (Story, Epic) ORDER BY created DESC'
+        issues = client.search_issues(jql)
+    finally:
+        if own_client:
+            client._client.close()
+
+    stats = {"created": 0, "updated": 0}
+    for issue in issues:
+        req_type = _ISSUE_TYPE_MAP.get((issue["issue_type"] or "").lower(), "feature")
+        status = _STATUS_CATEGORY_MAP.get(issue["status_category"], "active")
+        url = f"{client.base_url}/browse/{issue['key']}"
+
+        existing = db.query(models.Requirement).filter(
+            models.Requirement.external_key == issue["key"]
+        ).first()
+        if existing:
+            existing.title = issue["summary"] or existing.title
+            existing.type = req_type
+            existing.status = status
+            existing.external_url = url
+            stats["updated"] += 1
+        else:
+            req_id = "REQ-" + issue["key"].replace("-", "")
+            if db.query(models.Requirement).filter(models.Requirement.id == req_id).first():
+                req_id = "REQ-" + issue["key"].replace("-", "") + "-J"
+            db.add(models.Requirement(
+                id=req_id[:255],
+                title=issue["summary"] or issue["key"],
+                type=req_type,
+                status=status,
+                priority="med",
+                owner=issue.get("assignee"),
+                created_at="just now",
+                created_by="jira-sync",
+                external_provider="jira",
+                external_key=issue["key"],
+                external_url=url,
+            ))
+            stats["created"] += 1
+
+    integration.last_sync = datetime.now(timezone.utc).isoformat()
+    integration.status = "active"
+    db.commit()
+    return stats

--- a/backend/jira_sync.py
+++ b/backend/jira_sync.py
@@ -190,6 +190,30 @@ def push_defect_to_jira(db, integration, defect, client: JiraClient | None = Non
     return defect
 
 
+def sync_all_jira_integrations(db) -> dict:
+    """Sync every configured jira integration. Per-integration errors are logged and
+    skipped so one bad integration can't stall the others. Returns aggregate stats."""
+    import logging
+
+    log = logging.getLogger("thorotest.jira")
+    integrations = db.query(models.Integration).filter(models.Integration.type == "jira").all()
+    agg = {"integrations": 0, "created": 0, "updated": 0, "errors": 0}
+    for intg in integrations:
+        try:
+            stats = sync_jira_requirements(db, intg)
+            agg["integrations"] += 1
+            agg["created"] += stats.get("created", 0)
+            agg["updated"] += stats.get("updated", 0)
+            log.info("jira auto-sync %s: %s created, %s updated",
+                     intg.id, stats.get("created", 0), stats.get("updated", 0))
+        except (ValueError, RuntimeError) as e:
+            agg["errors"] += 1
+            intg.status = "error"
+            db.commit()
+            log.warning("jira auto-sync %s failed: %s", intg.id, e)
+    return agg
+
+
 def sync_jira_requirements(db, integration, client: JiraClient | None = None) -> dict:
     """Pull Jira stories/epics into requirements (upsert by external_key)."""
     cfg = integration.config or {}

--- a/backend/main.py
+++ b/backend/main.py
@@ -165,11 +165,52 @@ def _ensure_schema():
         command.stamp(cfg, "head")
 
 
+async def _jira_autosync_loop(interval_seconds: int):
+    """Background loop: periodically sync all jira integrations. Opt-in via
+    JIRA_AUTOSYNC_MINUTES > 0. Requires outbound reachability to Jira Cloud;
+    a no-op when no jira integration is configured."""
+    import asyncio
+
+    from .db import SessionLocal
+    from .jira_sync import sync_all_jira_integrations
+
+    log = logging.getLogger("thorotest.jira")
+    log.info("jira auto-sync enabled — every %s min", interval_seconds // 60)
+    while True:
+        try:
+            await asyncio.sleep(interval_seconds)
+            db = SessionLocal()
+            try:
+                # DB + network calls are blocking; run off the event loop.
+                await asyncio.to_thread(sync_all_jira_integrations, db)
+            finally:
+                db.close()
+        except asyncio.CancelledError:
+            break
+        except Exception as e:  # never let the loop die on an unexpected error
+            log.warning("jira auto-sync tick failed: %s", e)
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    import asyncio
+
     _ensure_schema()
     init_db()
+
+    task = None
+    minutes = int(os.getenv("JIRA_AUTOSYNC_MINUTES", "0") or "0")
+    if minutes > 0:
+        task = asyncio.create_task(_jira_autosync_loop(minutes * 60))
+
     yield
+
+    if task:
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
 
 
 app = FastAPI(title="ThoroTest API", lifespan=lifespan)

--- a/backend/main.py
+++ b/backend/main.py
@@ -433,7 +433,8 @@ async def initial_data(db: Session = Depends(get_db), _: models.User = Depends(g
     all_defects = db.query(models.Defect).order_by(models.Defect.id.desc()).limit(INITIAL_DATA_CAPS["defects"]).all()
     defects_out = [
         {"id": d.id, "title": d.title, "status": d.status, "severity": d.severity,
-         "testId": d.test_id, "runId": d.run_id}
+         "testId": d.test_id, "runId": d.run_id,
+         "externalKey": d.external_key, "externalUrl": d.external_url}
         for d in all_defects
     ]
 

--- a/backend/routers/defects.py
+++ b/backend/routers/defects.py
@@ -96,6 +96,37 @@ def update_defect(defect_id: str, payload: DefectUpdate, db: Session = Depends(g
     return d
 
 
+PUSH_ROLES = require_role("admin", "manager")
+
+
+@router.post("/defects/{defect_id}/push", response_model=DefectOut)
+def push_defect(defect_id: str, current_user: models.User = PUSH_ROLES, db: Session = Depends(get_db)):
+    """Create a Jira bug from this defect and store the external link on it."""
+    from ..jira_sync import push_defect_to_jira
+
+    d = db.query(models.Defect).filter(models.Defect.id == defect_id).first()
+    if not d:
+        raise HTTPException(status_code=404, detail="Defect not found")
+    if d.external_key:
+        raise HTTPException(status_code=409, detail=f"Defect already linked to {d.external_key}")
+
+    intg = db.query(models.Integration).filter(models.Integration.type == "jira").first()
+    if not intg:
+        raise HTTPException(status_code=400, detail="No Jira integration configured")
+
+    try:
+        push_defect_to_jira(db, intg, d)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except RuntimeError as e:
+        raise HTTPException(status_code=502, detail=str(e))
+
+    actor = current_user.display_name or current_user.username
+    log_activity(db, actor, "pushed defect to Jira", d.id, d.external_key or "")
+    db.commit()
+    return d
+
+
 @router.delete("/defects/{defect_id}", status_code=204)
 def delete_defect(defect_id: str, db: Session = Depends(get_db), _: models.User = ADMIN_ONLY):
     d = db.query(models.Defect).filter(models.Defect.id == defect_id).first()

--- a/backend/routers/integrations.py
+++ b/backend/routers/integrations.py
@@ -37,14 +37,20 @@ def update_integration(intg_id: str, payload: IntegrationUpdate, db: Session = D
         raise HTTPException(status_code=404, detail="Integration not found")
     updates = payload.model_dump(exclude_unset=True)
     if "config" in updates and updates["config"] is not None:
-        # Merge so a redacted/empty token from the client never wipes the stored one.
+        # Merge so a redacted/empty secret from the client never wipes the stored one.
         merged = dict(intg.config or {})
         incoming = updates.pop("config")
-        new_token = incoming.get("token")
+        prev = intg.config or {}
         merged.update(incoming)
-        if not new_token:
-            merged["token"] = (intg.config or {}).get("token", "")
+        # Preserve stored secrets when the client submits them blank (redacted).
+        for secret_key in ("token", "api_token"):
+            if not incoming.get(secret_key):
+                if prev.get(secret_key):
+                    merged[secret_key] = prev[secret_key]
+                else:
+                    merged.pop(secret_key, None)
         merged.pop("token_set", None)
+        merged.pop("api_token_set", None)
         intg.config = merged
     for field, value in updates.items():
         setattr(intg, field, value)

--- a/backend/routers/integrations.py
+++ b/backend/routers/integrations.py
@@ -6,6 +6,7 @@ from .. import models
 from ..schemas import IntegrationOut, IntegrationCreate, IntegrationUpdate
 from ..auth_utils import require_role, get_current_user
 from ..github_sync import sync_integration
+from ..jira_sync import sync_jira_requirements
 
 router = APIRouter(tags=["integrations"])
 
@@ -54,13 +55,16 @@ def update_integration(intg_id: str, payload: IntegrationUpdate, db: Session = D
 
 @router.post("/integrations/{intg_id}/sync")
 def sync_integration_now(intg_id: str, db: Session = Depends(get_db), _: models.User = WRITE_ROLES):
-    """Pull YAML tests from the integration's git repo (read-only) and upsert them."""
+    """Sync an integration. GitHub → pull YAML tests; Jira → pull stories/epics as requirements."""
     intg = db.query(models.Integration).filter(models.Integration.id == intg_id).first()
     if not intg:
         raise HTTPException(status_code=404, detail="Integration not found")
-    # sync_integration validates the config points at a github.com repo.
     try:
-        stats = sync_integration(db, intg)
+        if intg.type == "jira":
+            stats = sync_jira_requirements(db, intg)
+        else:
+            # sync_integration validates the config points at a github.com repo.
+            stats = sync_integration(db, intg)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     except RuntimeError as e:

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -173,6 +173,9 @@ class DefectOut(BaseModel):
     created_by: Optional[str] = None
     test_id: Optional[str] = None
     run_id: Optional[str] = None
+    external_provider: Optional[str] = None
+    external_key: Optional[str] = None
+    external_url: Optional[str] = None
 
     model_config = {"from_attributes": True}
 

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -380,13 +380,17 @@ class IntegrationOut(BaseModel):
     @field_validator("config", mode="before")
     @classmethod
     def _redact_token(cls, v):
-        """Never expose the stored PAT to clients; report only whether it is set."""
+        """Never expose stored secrets (GitHub PAT, Jira api_token) to clients;
+        report only whether each is set."""
         if not isinstance(v, dict):
             return {}
         out = dict(v)
         if out.get("token"):
             out["token"] = ""
             out["token_set"] = True
+        if out.get("api_token"):
+            out["api_token"] = ""
+            out["api_token_set"] = True
         return out
 
 

--- a/backend/tests/test_jira_sync.py
+++ b/backend/tests/test_jira_sync.py
@@ -1,0 +1,222 @@
+"""Tests for Jira integration — jira_sync logic, defect push, config redaction.
+
+No network: a FakeJiraClient is injected into push_defect_to_jira /
+sync_jira_requirements, and the endpoints are tested only on paths that don't
+reach Jira (validation, 404/409/400).
+"""
+import pytest
+from backend import models, jira_sync
+
+
+# ── FakeJiraClient ────────────────────────────────────────────────────────────
+
+class _FakeInner:
+    def close(self):
+        pass
+
+
+class FakeJiraClient:
+    base_url = "https://acme.atlassian.net"
+
+    def __init__(self, issues=None):
+        self._issues = issues or []
+        self.created = []
+        self._client = _FakeInner()
+
+    def create_issue(self, project_key, issue_type, summary, description=""):
+        self.created.append({"project_key": project_key, "issue_type": issue_type,
+                             "summary": summary, "description": description})
+        key = f"{project_key}-{len(self.created)}"
+        return {"key": key, "url": f"{self.base_url}/browse/{key}"}
+
+    def search_issues(self, jql, max_results=100):
+        return self._issues
+
+
+def _jira_integration(db):
+    intg = models.Integration(
+        id="int-jira", name="Jira", type="jira",
+        config={"base_url": "https://acme.atlassian.net", "email": "e@e.com",
+                "api_token": "tok", "project_key": "PAY", "issue_type_bug": "Bug"},
+    )
+    db.add(intg)
+    db.commit()
+    return intg
+
+
+# ── normalize_base_url ────────────────────────────────────────────────────────
+
+class TestNormalizeBaseUrl:
+    def test_strips_trailing_slash(self):
+        assert jira_sync.normalize_base_url("https://acme.atlassian.net/") == "https://acme.atlassian.net"
+
+    def test_requires_https(self):
+        with pytest.raises(ValueError):
+            jira_sync.normalize_base_url("http://acme.atlassian.net")
+
+    def test_empty_raises(self):
+        with pytest.raises(ValueError):
+            jira_sync.normalize_base_url("")
+
+
+# ── ADF ───────────────────────────────────────────────────────────────────────
+
+class TestAdf:
+    def test_wraps_paragraphs(self):
+        doc = jira_sync._adf("a\nb")
+        assert doc["type"] == "doc"
+        assert len(doc["content"]) == 2
+
+    def test_empty_still_valid(self):
+        doc = jira_sync._adf("")
+        assert doc["content"]
+
+
+# ── push_defect_to_jira ───────────────────────────────────────────────────────
+
+class TestPushDefect:
+    def test_push_stores_external_fields(self, db):
+        intg = _jira_integration(db)
+        d = models.Defect(id="BUG-1", title="Login broken", severity="high", description="steps")
+        db.add(d)
+        db.commit()
+        fake = FakeJiraClient()
+        jira_sync.push_defect_to_jira(db, intg, d, client=fake)
+        assert d.external_provider == "jira"
+        assert d.external_key == "PAY-1"
+        assert d.external_url == "https://acme.atlassian.net/browse/PAY-1"
+
+    def test_severity_prefixed_in_description(self, db):
+        intg = _jira_integration(db)
+        d = models.Defect(id="BUG-2", title="X", severity="critical", description="body")
+        db.add(d)
+        db.commit()
+        fake = FakeJiraClient()
+        jira_sync.push_defect_to_jira(db, intg, d, client=fake)
+        assert "severity: critical" in fake.created[0]["description"]
+
+    def test_re_push_raises(self, db):
+        intg = _jira_integration(db)
+        d = models.Defect(id="BUG-3", title="X", severity="med", external_key="PAY-9")
+        db.add(d)
+        db.commit()
+        with pytest.raises(ValueError):
+            jira_sync.push_defect_to_jira(db, intg, d, client=FakeJiraClient())
+
+    def test_missing_project_key_raises(self, db):
+        intg = models.Integration(id="int-jira", name="J", type="jira",
+                                  config={"base_url": "https://x.atlassian.net", "email": "e", "api_token": "t"})
+        db.add(intg)
+        d = models.Defect(id="BUG-4", title="X", severity="low")
+        db.add(d)
+        db.commit()
+        with pytest.raises(ValueError):
+            jira_sync.push_defect_to_jira(db, intg, d, client=FakeJiraClient())
+
+
+# ── sync_jira_requirements ────────────────────────────────────────────────────
+
+class TestSyncRequirements:
+    def _issues(self):
+        return [
+            {"key": "PAY-1", "summary": "Login story", "status_category": "done", "issue_type": "Story", "assignee": "a@b.com"},
+            {"key": "PAY-2", "summary": "Checkout epic", "status_category": "indeterminate", "issue_type": "Epic", "assignee": None},
+            {"key": "PAY-3", "summary": "Some task", "status_category": "new", "issue_type": "Task", "assignee": None},
+        ]
+
+    def test_creates_requirements(self, db):
+        intg = _jira_integration(db)
+        stats = jira_sync.sync_jira_requirements(db, intg, client=FakeJiraClient(self._issues()))
+        assert stats == {"created": 3, "updated": 0}
+        assert db.query(models.Requirement).count() == 3
+
+    def test_type_and_status_mapping(self, db):
+        intg = _jira_integration(db)
+        jira_sync.sync_jira_requirements(db, intg, client=FakeJiraClient(self._issues()))
+        by_key = {r.external_key: r for r in db.query(models.Requirement).all()}
+        assert by_key["PAY-1"].type == "story" and by_key["PAY-1"].status == "done"
+        assert by_key["PAY-2"].type == "epic" and by_key["PAY-2"].status == "active"
+        assert by_key["PAY-3"].type == "feature" and by_key["PAY-3"].status == "active"
+
+    def test_upsert_on_resync(self, db):
+        intg = _jira_integration(db)
+        jira_sync.sync_jira_requirements(db, intg, client=FakeJiraClient(self._issues()))
+        changed = [{"key": "PAY-1", "summary": "Renamed story", "status_category": "new", "issue_type": "Story", "assignee": None}]
+        stats = jira_sync.sync_jira_requirements(db, intg, client=FakeJiraClient(changed))
+        assert stats == {"created": 0, "updated": 1}
+        r = db.query(models.Requirement).filter(models.Requirement.external_key == "PAY-1").first()
+        assert r.title == "Renamed story"
+
+    def test_preserves_local_test_links(self, db):
+        intg = _jira_integration(db)
+        db.add(models.Test(id="TC-1", title="t", status="pass"))
+        db.commit()
+        jira_sync.sync_jira_requirements(db, intg, client=FakeJiraClient(self._issues()))
+        r = db.query(models.Requirement).filter(models.Requirement.external_key == "PAY-1").first()
+        r.tests = db.query(models.Test).filter(models.Test.id == "TC-1").all()
+        db.commit()
+        # re-sync must not drop the link
+        jira_sync.sync_jira_requirements(db, intg, client=FakeJiraClient(self._issues()))
+        r = db.query(models.Requirement).filter(models.Requirement.external_key == "PAY-1").first()
+        assert [t.id for t in r.tests] == ["TC-1"]
+
+
+# ── defect push endpoint (no network paths) ───────────────────────────────────
+
+class TestPushEndpoint:
+    def test_404_unknown_defect(self, client, db):
+        assert client.post("/api/defects/BUG-NOPE/push").status_code == 404
+
+    def test_400_no_jira_integration(self, client, db):
+        db.add(models.Defect(id="BUG-1", title="X", severity="med"))
+        db.commit()
+        assert client.post("/api/defects/BUG-1/push").status_code == 400
+
+    def test_409_already_linked(self, client, db):
+        _jira_integration(db)
+        db.add(models.Defect(id="BUG-1", title="X", severity="med", external_key="PAY-5"))
+        db.commit()
+        assert client.post("/api/defects/BUG-1/push").status_code == 409
+
+    def test_viewer_forbidden(self, auth_client, db):
+        _jira_integration(db)
+        db.add(models.Defect(id="BUG-1", title="X", severity="med"))
+        db.commit()
+        assert auth_client("viewer").post("/api/defects/BUG-1/push").status_code == 403
+
+
+# ── config secret redaction ───────────────────────────────────────────────────
+
+class TestSecretRedaction:
+    def test_api_token_not_returned(self, client, db):
+        r = client.post("/api/integrations", json={
+            "id": "int-jira", "name": "Jira", "type": "jira",
+            "config": {"base_url": "https://acme.atlassian.net", "email": "e@e.com",
+                       "api_token": "SECRET123", "project_key": "PAY"},
+        })
+        assert r.status_code == 201
+        cfg = r.json()["config"]
+        assert cfg["api_token"] == ""
+        assert cfg["api_token_set"] is True
+
+    def test_secret_not_leaked_in_list(self, client, db):
+        client.post("/api/integrations", json={
+            "id": "int-jira", "name": "Jira", "type": "jira",
+            "config": {"base_url": "https://acme.atlassian.net", "email": "e@e.com",
+                       "api_token": "SECRET123", "project_key": "PAY"},
+        })
+        assert "SECRET123" not in str(client.get("/api/integrations").json())
+
+    def test_blank_api_token_preserved_on_patch(self, client, db):
+        client.post("/api/integrations", json={
+            "id": "int-jira", "name": "Jira", "type": "jira",
+            "config": {"base_url": "https://acme.atlassian.net", "email": "e@e.com",
+                       "api_token": "SECRET123", "project_key": "PAY"},
+        })
+        client.patch("/api/integrations/int-jira", json={
+            "config": {"base_url": "https://acme.atlassian.net", "email": "e@e.com",
+                       "api_token": "", "project_key": "PAY2"},
+        })
+        stored = db.query(models.Integration).filter(models.Integration.id == "int-jira").first().config
+        assert stored["api_token"] == "SECRET123"
+        assert stored["project_key"] == "PAY2"

--- a/backend/tests/test_jira_sync.py
+++ b/backend/tests/test_jira_sync.py
@@ -161,6 +161,37 @@ class TestSyncRequirements:
         assert [t.id for t in r.tests] == ["TC-1"]
 
 
+# ── sync_all_jira_integrations ────────────────────────────────────────────────
+
+class TestSyncAll:
+    def _issues(self):
+        return [{"key": "PAY-1", "summary": "Story", "status_category": "new", "issue_type": "Story", "assignee": None}]
+
+    def test_aggregates_and_skips_github(self, db, monkeypatch):
+        _jira_integration(db)
+        db.add(models.Integration(id="int-gh", name="GH", type="github", config={"repo_url": "https://github.com/a/b"}))
+        db.commit()
+        fake = FakeJiraClient(self._issues())
+        monkeypatch.setattr(jira_sync, "_client_from_config", lambda cfg: fake)
+        agg = jira_sync.sync_all_jira_integrations(db)
+        assert agg["integrations"] == 1
+        assert agg["created"] == 1
+        assert agg["errors"] == 0
+        assert db.query(models.Requirement).count() == 1
+
+    def test_error_isolated_per_integration(self, db):
+        # jira integration missing api_token → error, but loop returns cleanly
+        db.add(models.Integration(id="int-jira", name="J", type="jira",
+                                  config={"base_url": "https://x.atlassian.net", "email": "e", "project_key": "P"}))
+        db.commit()
+        agg = jira_sync.sync_all_jira_integrations(db)
+        assert agg["errors"] == 1
+        assert agg["integrations"] == 0
+
+    def test_no_jira_integration_is_noop(self, db):
+        assert jira_sync.sync_all_jira_integrations(db) == {"integrations": 0, "created": 0, "updated": 0, "errors": 0}
+
+
 # ── defect push endpoint (no network paths) ───────────────────────────────────
 
 class TestPushEndpoint:

--- a/e2e/suite19-jira/jira.spec.ts
+++ b/e2e/suite19-jira/jira.spec.ts
@@ -1,0 +1,89 @@
+import { test, expect } from '@playwright/test';
+import { loginAs } from '../fixtures/auth';
+
+const BASE = 'http://localhost:8000';
+
+async function token(page: any): Promise<string> {
+  return await page.evaluate(() => localStorage.getItem('th_token') ?? '');
+}
+
+test.describe('Suite 19 — Jira integration (no live Jira)', () => {
+
+  test.afterEach(async ({ page }) => {
+    // Clean up any jira integration this suite created
+    const t = await token(page).catch(() => '');
+    if (t) {
+      await page.request.delete(`${BASE}/api/integrations/int-jira-e2e`, { headers: { Authorization: `Bearer ${t}` } }).catch(() => {});
+    }
+  });
+
+  // JIRA-01 · Integration create redacts api_token [P1]
+  test('JIRA-01: creating a jira integration never returns api_token', async ({ page }) => {
+    await loginAs(page, 'marco@acme.com');
+    const t = await token(page);
+    const res = await page.request.post(`${BASE}/api/integrations`, {
+      data: {
+        id: 'int-jira-e2e', name: 'Jira E2E', type: 'jira',
+        config: { base_url: 'https://acme.atlassian.net', email: 'e@e.com', api_token: 'SECRET_E2E', project_key: 'PAY' },
+      },
+      headers: { Authorization: `Bearer ${t}`, 'Content-Type': 'application/json' },
+    });
+    expect(res.status()).toBe(201);
+    const cfg = (await res.json()).config;
+    expect(cfg.api_token).toBe('');
+    expect(cfg.api_token_set).toBe(true);
+  });
+
+  // JIRA-02 · Secret not leaked in list [P1]
+  test('JIRA-02: api_token not present in GET /api/integrations', async ({ page }) => {
+    await loginAs(page, 'marco@acme.com');
+    const t = await token(page);
+    await page.request.post(`${BASE}/api/integrations`, {
+      data: {
+        id: 'int-jira-e2e', name: 'Jira E2E', type: 'jira',
+        config: { base_url: 'https://acme.atlassian.net', email: 'e@e.com', api_token: 'SECRET_E2E', project_key: 'PAY' },
+      },
+      headers: { Authorization: `Bearer ${t}`, 'Content-Type': 'application/json' },
+    });
+    const list = await page.request.get(`${BASE}/api/integrations`, { headers: { Authorization: `Bearer ${t}` } });
+    expect(JSON.stringify(await list.json())).not.toContain('SECRET_E2E');
+  });
+
+  // JIRA-03 · Push unknown defect → 404 [P2]
+  test('JIRA-03: push unknown defect returns 404', async ({ page }) => {
+    await loginAs(page, 'marco@acme.com');
+    const t = await token(page);
+    const res = await page.request.post(`${BASE}/api/defects/BUG-NOPE-XYZ/push`, { headers: { Authorization: `Bearer ${t}` } });
+    expect(res.status()).toBe(404);
+  });
+
+  // JIRA-04 · Jira appears in the add-integration picker [P2]
+  test('JIRA-04: Jira is offered as an integration provider', async ({ page }) => {
+    await loginAs(page, 'marco@acme.com');
+    await page.goto('/#/integrations');
+    await expect(page.locator('h1:has-text("Integrations")')).toBeVisible({ timeout: 10000 });
+    await page.click('button:has-text("Add integration")');
+    await expect(page.locator('button:has-text("Jira")')).toBeVisible({ timeout: 8000 });
+  });
+
+  // JIRA-05 · Jira config form renders its fields [P2]
+  test('JIRA-05: Jira config form shows base URL + project key + API token', async ({ page }) => {
+    await loginAs(page, 'marco@acme.com');
+    await page.goto('/#/integrations');
+    await expect(page.locator('h1:has-text("Integrations")')).toBeVisible({ timeout: 10000 });
+    await page.click('button:has-text("Add integration")');
+    await page.click('button:has-text("Jira")');
+    await expect(page.locator('input[placeholder="https://acme.atlassian.net"]')).toBeVisible({ timeout: 8000 });
+    await expect(page.locator('input[placeholder="PAY"]')).toBeVisible();
+    await expect(page.locator('input[placeholder="Atlassian API token"]')).toBeVisible();
+  });
+
+  // JIRA-06 · Defects view exposes a Tracker column with Push to Jira [P2]
+  test('JIRA-06: defects view has a Push to Jira action', async ({ page }) => {
+    await loginAs(page, 'marco@acme.com');
+    await page.goto('/#/defects');
+    await expect(page.locator('h1:has-text("Defects")')).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('th:has-text("Tracker")')).toBeVisible({ timeout: 8000 });
+    await expect(page.locator('button:has-text("Push to Jira")').first()).toBeVisible({ timeout: 8000 });
+  });
+});

--- a/frontend/api.js
+++ b/frontend/api.js
@@ -312,6 +312,16 @@
       if (!res.ok && res.status !== 204) throw new Error("Delete defect failed");
     },
 
+    async pushDefectToJira(id) {
+      const res = await fetch(BASE + `/api/defects/${id}/push`, { method: "POST", headers: authHeaders() });
+      if (!res.ok) {
+        let msg = "Push to Jira failed";
+        try { msg = (await res.json()).detail || msg; } catch {}
+        throw new Error(msg);
+      }
+      return res.json();
+    },
+
     async getRunDefects(runId) {
       const res = await fetch(BASE + `/api/runs/${runId}/defects`, { headers: authHeaders() });
       if (!res.ok) throw new Error("Run defects fetch failed");

--- a/frontend/views/view-config.jsx
+++ b/frontend/views/view-config.jsx
@@ -7,6 +7,7 @@ const PROVIDERS = [
   { id: "playwright", name: "Playwright",  icon: "plug",    type: "runner",        configuredBy: "playwright.config.ts" },
   { id: "cypress",    name: "Cypress",     icon: "plug",    type: "runner",        configuredBy: "cypress.config.js" },
   { id: "jest",       name: "Jest",        icon: "plug",    type: "runner",        configuredBy: "jest.config.js" },
+  { id: "jira",       name: "Jira",        icon: "plug",    type: "issue_tracker", configuredBy: "" },
   { id: "linear",     name: "Linear",      icon: "plug",    type: "defects",       configuredBy: "ACME workspace" },
   { id: "slack",      name: "Slack",       icon: "plug",    type: "notifications", configuredBy: "#qa-alerts" },
   { id: "webhook",    name: "Webhook",     icon: "plug",    type: "outbound",      configuredBy: "" },
@@ -14,7 +15,8 @@ const PROVIDERS = [
 
 const TYPE_LABELS = {
   vcs_ci: "VCS + CI", ci: "CI", runner: "Runner",
-  defects: "Defects", notifications: "Notifications", outbound: "Outbound",
+  defects: "Defects", issue_tracker: "Issue tracker",
+  notifications: "Notifications", outbound: "Outbound",
 };
 
 const WEBHOOK_EVENTS = ["run.completed", "run.failed", "defect.created", "defect.updated"];
@@ -57,12 +59,44 @@ function GithubConfigFields({ form, setForm, tokenSet }) {
   );
 }
 
+function JiraConfigFields({ form, setForm, tokenSet }) {
+  const fld = { marginBottom:12 };
+  const lbl = { display:"block", fontSize:12, fontWeight:500, color:"var(--text-muted)", marginBottom:6 };
+  const set = (k) => (e) => setForm(f => ({ ...f, [k]: e.target.value }));
+  return (
+    <>
+      <div style={fld}>
+        <label style={lbl}>Jira base URL</label>
+        <input className="login-input" value={form.base_url} onChange={set("base_url")} placeholder="https://acme.atlassian.net" style={{width:"100%"}} />
+      </div>
+      <div style={{display:"flex", gap:8}}>
+        <div style={{...fld, flex:2}}>
+          <label style={lbl}>Account email</label>
+          <input className="login-input" value={form.email} onChange={set("email")} placeholder="you@acme.com" style={{width:"100%"}} />
+        </div>
+        <div style={{...fld, flex:1}}>
+          <label style={lbl}>Project key</label>
+          <input className="login-input" value={form.project_key} onChange={set("project_key")} placeholder="PAY" style={{width:"100%"}} />
+        </div>
+      </div>
+      <div style={fld}>
+        <label style={lbl}>API token {tokenSet ? "(leave blank to keep current)" : ""}</label>
+        <input className="login-input" type="password" value={form.api_token} onChange={set("api_token")} placeholder={tokenSet ? "••••••••" : "Atlassian API token"} autoComplete="off" style={{width:"100%"}} />
+      </div>
+      <div style={fld}>
+        <label style={lbl}>Bug issue type</label>
+        <input className="login-input" value={form.issue_type_bug} onChange={set("issue_type_bug")} placeholder="Bug" style={{width:"100%"}} />
+      </div>
+    </>
+  );
+}
+
 function IntRow({ intg, onEdit, onDelete, onSync }) {
   const [menuOpen, setMenuOpen] = React.useState(false);
   const [syncing, setSyncing] = React.useState(false);
   const [syncMsg, setSyncMsg] = React.useState(null);
   const menuRef = React.useRef(null);
-  const canSync = !!(intg.config && intg.config.repo_url);
+  const canSync = !!(intg.config && (intg.config.repo_url || (intg.type === "jira" && intg.config.base_url)));
 
   const doSync = async () => {
     setSyncing(true); setSyncMsg(null);
@@ -145,10 +179,14 @@ function AddIntegrationModal({ onClose, onSaved, existingIds }) {
   useEscapeClose(onClose);
 
   const isGithub = provider?.id === "github";
+  const isJira = provider?.id === "jira";
 
   const pick = (p) => {
     setProvider(p);
-    setForm({ configured_by: p.configuredBy, repo_url: "", branch: "main", path: "", token: "" });
+    setForm({
+      configured_by: p.configuredBy, repo_url: "", branch: "main", path: "", token: "",
+      base_url: "", email: "", api_token: "", project_key: "", issue_type_bug: "Bug",
+    });
     setStep("configure");
   };
 
@@ -166,6 +204,14 @@ function AddIntegrationModal({ onClose, onSaved, existingIds }) {
           branch: form.branch.trim() || "main",
           path: form.path.trim(),
           token: form.token.trim(),
+        };
+      } else if (isJira) {
+        payload.config = {
+          base_url: form.base_url.trim(),
+          email: form.email.trim(),
+          api_token: form.api_token.trim(),
+          project_key: form.project_key.trim(),
+          issue_type_bug: form.issue_type_bug.trim() || "Bug",
         };
       }
       const created = await TH_API.createIntegration(payload);
@@ -217,6 +263,7 @@ function AddIntegrationModal({ onClose, onSaved, existingIds }) {
               />
             </div>
             {isGithub && <GithubConfigFields form={form} setForm={setForm} tokenSet={false} />}
+            {isJira && <JiraConfigFields form={form} setForm={setForm} tokenSet={false} />}
             {err && <div style={{fontSize:12, color:"var(--fail)", marginBottom:8}}>{err}</div>}
             <div style={{display:"flex", gap:8}}>
               <button className="btn primary" onClick={save} disabled={saving}>{saving ? "Connecting…" : "Connect"}</button>
@@ -233,10 +280,14 @@ function EditIntegrationModal({ intg, onClose, onSaved }) {
   useEscapeClose(onClose);
   const cfg = intg.config || {};
   const isGithub = intg.icon === "github" || !!cfg.repo_url;
+  const isJira = intg.type === "jira";
   const tokenSet = !!cfg.token_set;
+  const apiTokenSet = !!cfg.api_token_set;
   const [form, setForm] = React.useState({
     name: intg.name, configured_by: intg.configured_by || "", status: intg.status,
     repo_url: cfg.repo_url || "", branch: cfg.branch || "main", path: cfg.path || "", token: "",
+    base_url: cfg.base_url || "", email: cfg.email || "", api_token: "",
+    project_key: cfg.project_key || "", issue_type_bug: cfg.issue_type_bug || "Bug",
   });
   const [saving, setSaving] = React.useState(false);
   const [err, setErr] = React.useState(null);
@@ -254,6 +305,15 @@ function EditIntegrationModal({ intg, onClose, onSaved }) {
           branch: form.branch.trim() || "main",
           path: form.path.trim(),
           token: form.token.trim(),
+        };
+      } else if (isJira) {
+        // Empty api_token is preserved server-side (never wiped by a blank field).
+        payload.config = {
+          base_url: form.base_url.trim(),
+          email: form.email.trim(),
+          api_token: form.api_token.trim(),
+          project_key: form.project_key.trim(),
+          issue_type_bug: form.issue_type_bug.trim() || "Bug",
         };
       }
       const updated = await TH_API.updateIntegration(intg.id, payload);
@@ -283,6 +343,7 @@ function EditIntegrationModal({ intg, onClose, onSaved }) {
           </select>
         </div>
         {isGithub && <GithubConfigFields form={form} setForm={setForm} tokenSet={tokenSet} />}
+        {isJira && <JiraConfigFields form={form} setForm={setForm} tokenSet={apiTokenSet} />}
         {err && <div style={{fontSize:12, color:"var(--fail)", marginBottom:8}}>{err}</div>}
         <div style={{display:"flex", gap:8}}>
           <button className="btn primary" onClick={save} disabled={saving}>{saving ? "Saving…" : "Save"}</button>

--- a/frontend/views/view-defects.jsx
+++ b/frontend/views/view-defects.jsx
@@ -42,6 +42,17 @@ function Defects() {
     setDeleteConfirmId(null);
   };
 
+  const [pushingId, setPushingId] = useState(null);
+  const [pushErr, setPushErr] = useState(null);
+  const handlePush = async (id) => {
+    setPushingId(id); setPushErr(null);
+    try {
+      const updated = await TH_API.pushDefectToJira(id);
+      setDefects(prev => prev.map(d => d.id === id ? updated : d));
+    } catch (e) { setPushErr({ id, msg: e.message }); }
+    setPushingId(null);
+  };
+
   const severityClass = s => s === "critical" || s === "high" ? "priority-high" : s === "med" ? "priority-med" : "priority-low";
   const statusColor = s => {
     if (s === "open") return "var(--fail)";
@@ -126,6 +137,7 @@ function Defects() {
                   <th style={{width:90}}>Severity</th>
                   <th style={{width:90}}>Test</th>
                   <th style={{width:90}}>Run</th>
+                  <th style={{width:110}}>Tracker</th>
                   <th style={{width:80}}>Filed</th>
                   <th style={{width:32}}></th>
                 </tr>
@@ -159,6 +171,18 @@ function Defects() {
                     <td><span className={"tag " + severityClass(d.severity)}>{d.severity}</span></td>
                     <td className="mono" style={{fontSize:11}}>{d.test_id || <span className="dim">—</span>}</td>
                     <td className="mono" style={{fontSize:11}}>{d.run_id || <span className="dim">—</span>}</td>
+                    <td style={{fontSize:11}}>
+                      {d.external_key ? (
+                        <a href={d.external_url || "#"} target="_blank" rel="noreferrer" className="mono" style={{color:"var(--accent)", textDecoration:"none"}}>{d.external_key}</a>
+                      ) : (
+                        <>
+                          <button className="btn ghost sm" style={{padding:"2px 6px"}} disabled={pushingId === d.id} onClick={() => handlePush(d.id)} title="Create a Jira bug from this defect">
+                            {pushingId === d.id ? "Pushing…" : "Push to Jira"}
+                          </button>
+                          {pushErr && pushErr.id === d.id && <div style={{fontSize:10, color:"var(--fail)", marginTop:2, maxWidth:100}}>{pushErr.msg}</div>}
+                        </>
+                      )}
+                    </td>
                     <td className="dim" style={{fontSize:11}}>{d.created_at || "—"}</td>
                     <td>
                       <button

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thorotest",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Source-available test management platform. Organize, run, and track tests across manual and automated suites — one timeline for both.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary

Two-way link with **Jira Cloud**, reusing the `external_*` fields shipped in v1.1 on Requirement and Defect — no schema change. Ships as **v1.2.0**.

- **Pull** (inbound): Sync runs a JQL query (`project = KEY AND issuetype in (Story, Epic)`) and upserts issues as requirements, matched by `external_key`, with status/issuetype mapping. Local test links preserved across re-syncs.
- **Push** (outbound): "Push to Jira" on the Defects view creates a bug from a defect and stores the issue key + URL. Re-push rejected (409).

## What's included

**Backend**
- `jira_sync.py`: `JiraClient` (Cloud REST v3, Basic auth), `push_defect_to_jira`, `sync_jira_requirements`. HTTP layer separated for test injection. base_url validation (https/Atlassian), ADF description, severity→priority map.
- integrations sync endpoint branches on `type` (jira vs github)
- `POST /api/defects/{id}/push` (admin/manager): 404 / 409 / 400 / 502 paths
- `DefectOut` + initial-data expose `external_provider/key/url`

**Frontend**
- Integrations config: Jira provider + form (base_url, email, api_token, project_key, bug type); Sync enabled for jira
- Defects view: Tracker column — Push to Jira, external key link once pushed

**Security**
- `api_token` never returned to clients (`api_token_set: true` only), preserved on blank edit — same handling as the GitHub PAT
- Extended the config redaction that previously only covered `token`

## Tests

- pytest: **20 new** (sync mapping/upsert/link-preservation, defect push + guards, push endpoint 404/400/409/403, api_token redaction) — **437 total pass**, no regressions
- e2e `suite19-jira`: **6 pass** (redaction, no-leak, push 404, provider in picker, config form, Push-to-Jira action)

No live Jira required — HTTP client is faked in tests.

## Not in this PR (deferred)

Inbound webhook for real-time Jira status changes (polling on Sync covers status today). Would need a publicly reachable instance + secret validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)