### PR TITLE
chore(release): bump version to 1.3.0

### DIFF
--- a/PRODUCTION_ROADMAP.md
+++ b/PRODUCTION_ROADMAP.md
@@ -21,6 +21,7 @@ not yet sellable production. Items ordered by priority — work top to bottom.
 |---|---|---|
 | 1.1 | Requirements & test coverage (features/stories/epics ↔ tests, coverage metrics, YAML/JSON/CSV import, GraphQL) | ✅ Done — `feat/requirements-coverage` |
 | 1.2 | Jira integration (pull stories → requirements, push defects → bugs) — reuses `external_*` fields shipped in 1.1 | ✅ Done — `feat/jira-integration` |
+| 1.3 | External importers (TestRail/TestLink XML, qTest/Xray/Zephyr JSON, real .xlsx) + external-identity matching/dedup | ✅ Done — `feat/external-importers` |
 
 ## Item detail
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thorotest",
-  "version": "1.0.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thorotest",
-      "version": "1.0.0",
+      "version": "1.3.0",
       "license": "SEE LICENSE IN LICENSE",
       "devDependencies": {
         "@playwright/test": "^1.60.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thorotest",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Source-available test management platform. Organize, run, and track tests across manual and automated suites — one timeline for both.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Bumps `package.json` / `package-lock.json` to **1.3.0** and records the release in the roadmap.

1.3.0 = the external-importers release merged in #5:
- TestRail XML, TestLink XML
- qTest JSON, Xray JSON, Zephyr Scale JSON
- real `.xlsx` spreadsheet import
- external-identity (`external_provider`/`external_key`) matching + dedup on re-import

🤖 Generated with [Claude Code](https://claude.com/claude-code)