### PR TITLE
fix(overview): folder names (not F- ids) in AI edge-case picker

### DIFF
--- a/frontend/views/view-overview.jsx
+++ b/frontend/views/view-overview.jsx
@@ -187,11 +187,15 @@ function Overview({ onNav, currentUser }) {
 // Compact AI coverage widget — analyzes a folder's tests via /api/ai/suggest-edge-cases
 // and can create pending draft tests from the suggestions.
 function AiSuggestBox({ D }) {
+  // Map every folder id → name across the whole tree (any depth). Imported
+  // folders nest several levels deep, so a shallow walk left leaf ids showing
+  // as raw "F-…" in the picker.
   const folderNames = {};
-  D.folders.forEach(f => {
+  const walkFolders = (list) => (list || []).forEach(f => {
     folderNames[f.id] = f.name;
-    (f.children || []).forEach(c => { folderNames[c.id] = c.name; });
+    walkFolders(f.children);
   });
+  walkFolders(D.folders);
   const folderIds = [...new Set(D.tests.map(t => t.folder).filter(Boolean))];
 
   const [folderId, setFolderId] = React.useState(folderIds[0] || "");

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thorotest",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thorotest",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "SEE LICENSE IN LICENSE",
       "devDependencies": {
         "@playwright/test": "^1.60.0",
@@ -670,7 +670,7 @@
       "license": "MIT"
     },
     "node_modules/loose-envify": {
-      "version": "1.4.0",
+      "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "dev": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thorotest",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Source-available test management platform. Organize, run, and track tests across manual and automated suites — one timeline for both.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The AI assistant's **Find missing edge cases** folder dropdown (Overview) showed raw folder ids like `F-872706FE` instead of folder names.

Cause: the id→name map was built only from top-level folders + their direct children (two levels). Deeply nested folders — e.g. imported `backend/tests/test_admin/TestAdmin` — had no entry, so the picker fell back to the id. Fixed by walking the whole folder tree recursively.

Browser check: the dropdown now lists names (`integrations.spec.ts`, `test_totp`, …) with no `F-` labels.

Patch release 1.4.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)