### PR TITLE
feat(gitlab): real GitLab integration (sync + CI)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ test-results/
 
 # Local-only notes (never commit)
 *.local.md
+
+*.log

--- a/backend/gitlab_actions.py
+++ b/backend/gitlab_actions.py
@@ -1,0 +1,90 @@
+"""GitLab CI orchestration: trigger a pipeline and collect its test report.
+
+Simpler than the GitHub Actions flow: creating a pipeline
+(``POST /projects/:id/pipeline``) returns the pipeline id immediately, so
+there's no "find the dispatched run" step. Results come from the structured
+test-report endpoint (``GET /pipelines/:id/test_report``) rather than a JUnit
+artifact, so the workflow needs no artifact wiring — just a ``.gitlab-ci.yml``
+whose jobs declare ``artifacts: reports: junit:``. The PAT needs scope ``api``.
+"""
+import httpx
+
+from .gitlab_sync import GitLabClient, parse_gitlab_repo
+from .importers.base import ImportResult, TestData, RunData, CaseResult
+from .importers.junit_xml import _folder_for
+from .importers.persist import persist_import_result
+
+PROVIDER = "gitlab-ci"
+
+# GitLab test_case.status → ThoroTest case status.
+_STATUS_MAP = {
+    "success": "pass",
+    "failed": "fail",
+    "error": "fail",
+    "skipped": "blocked",
+}
+
+# Pipeline statuses that mean "finished".
+_TERMINAL = {"success", "failed", "canceled", "skipped"}
+
+
+class GitLabActionsClient(GitLabClient):
+    """Adds the CI (pipeline) endpoints to the base REST wrapper."""
+
+    def trigger_pipeline(self, project: str, ref: str) -> dict:
+        r = self._client.post(
+            f"/projects/{self._enc(project)}/pipeline",
+            json={"ref": ref},
+        )
+        if r.status_code not in (200, 201):
+            raise RuntimeError(f"pipeline trigger failed ({r.status_code}): {r.text[:300]}")
+        return r.json()
+
+    def get_pipeline(self, project: str, pipeline_id: int) -> dict:
+        r = self._get(f"/projects/{self._enc(project)}/pipelines/{pipeline_id}")
+        return r.json()
+
+    def get_test_report(self, project: str, pipeline_id: int) -> dict:
+        r = self._get(f"/projects/{self._enc(project)}/pipelines/{pipeline_id}/test_report")
+        return r.json()
+
+
+# ── Pure helpers (unit-testable without the network) ──────────────
+
+def parse_test_report(report: dict, run_name: str) -> ImportResult:
+    """Map a GitLab pipeline test_report JSON blob to an ImportResult."""
+    tests: list[TestData] = []
+    cases: list[CaseResult] = []
+    for suite in report.get("test_suites", []):
+        suite_name = suite.get("name") or ""
+        for tc in suite.get("test_cases", []):
+            title = tc.get("name") or "(unnamed)"
+            classname = tc.get("classname") or ""
+            status = _STATUS_MAP.get(tc.get("status"), "pending")
+            folder = _folder_for(suite_name, classname)
+            tests.append(TestData(title=title, folder_path=folder,
+                                  type="automated", status=status))
+            cases.append(CaseResult(test_title=title, status=status))
+    runs = [RunData(name=run_name, status="done", cases=cases)]
+    return ImportResult(tests=tests, runs=runs, format_detected="gitlab_test_report")
+
+
+def collect_pipeline_results(db, client, project: str, pipeline_id: int,
+                             run_name: str | None) -> dict:
+    """Download the pipeline's test report and import it. Returns import stats."""
+    report = client.get_test_report(project, pipeline_id)
+    name = run_name or f"GitLab pipeline #{pipeline_id}"
+    result = parse_test_report(report, name)
+    return persist_import_result(db, result, PROVIDER, conflict="skip")
+
+
+def ci_config(integration) -> dict:
+    """Pull the CI-relevant fields off a gitlab integration's config."""
+    cfg = integration.config or {}
+    api_base, project = parse_gitlab_repo(cfg.get("repo_url", ""), cfg.get("api_base"))
+    return {
+        "api_base": api_base,
+        "project": project,
+        "token": cfg.get("token") or None,
+        "ref": cfg.get("branch") or "main",
+    }

--- a/backend/gitlab_sync.py
+++ b/backend/gitlab_sync.py
@@ -1,0 +1,150 @@
+"""GitLab "Tests as Code" sync — read-only (git → ThoroTest).
+
+Mirror of :mod:`backend.github_sync` for GitLab (gitlab.com or self-hosted).
+Reuses the provider-agnostic upsert in ``github_sync.sync_repo`` by injecting a
+GitLab fetcher, so folder-tree building, source-link recording, and idempotent
+matching are shared. Auth is a Personal Access Token (scope ``api``, or
+``read_api`` for sync only) stored in the integration config.
+"""
+from urllib.parse import urlsplit, quote
+from datetime import datetime, timezone
+
+import httpx
+
+from . import models  # noqa: F401  (kept for symmetry / future use)
+from .github_sync import sync_repo
+
+_YAML_EXT = (".yml", ".yaml")
+
+
+def parse_gitlab_repo(repo_url: str, api_base: str | None = None) -> tuple[str, str]:
+    """``https://gitlab.com/group/sub/repo(.git)`` → ``(api_base, project_path)``.
+
+    ``project_path`` keeps sub-groups ("group/sub/repo") and is URL-encoded by
+    the client when placed in a path segment. ``api_base`` defaults to
+    ``<scheme>://<host[:port]>/api/v4`` derived from the repo URL (works for
+    self-hosted), and may be overridden.
+    """
+    if not repo_url:
+        raise ValueError("repo_url is required")
+    url = repo_url.strip()
+    # Support scp-like SSH form: git@host:group/repo.git
+    if url.startswith("git@") or ("@" in url and "://" not in url):
+        host, _, path = url.partition(":")
+        host = host.split("@", 1)[-1]
+        derived_base = f"https://{host}/api/v4"
+        project = path
+    else:
+        parts = urlsplit(url)
+        if not parts.netloc:
+            raise ValueError(f"not a gitlab repo url: {repo_url}")
+        derived_base = f"{parts.scheme}://{parts.netloc}/api/v4"
+        project = parts.path
+    project = project.strip("/")
+    if project.endswith(".git"):
+        project = project[:-4]
+    if not project or "/" not in project:
+        raise ValueError(f"not a gitlab repo url: {repo_url}")
+    return (api_base.rstrip("/") if api_base else derived_base), project
+
+
+class GitLabClient:
+    """Thin GitLab REST v4 wrapper. Raises RuntimeError on API errors."""
+
+    def __init__(self, api_base: str, token: str | None = None, timeout: float = 15.0):
+        headers = {"Accept": "application/json"}
+        if token:
+            headers["PRIVATE-TOKEN"] = token
+        self._client = httpx.Client(base_url=api_base.rstrip("/"), headers=headers,
+                                    timeout=timeout, follow_redirects=True)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self._client.close()
+
+    @staticmethod
+    def _enc(project: str) -> str:
+        return quote(project, safe="")
+
+    def _get(self, url: str, **kwargs):
+        try:
+            r = self._client.get(url, **kwargs)
+        except httpx.HTTPError as e:
+            raise RuntimeError(f"gitlab request failed: {e}")
+        if r.status_code == 404:
+            raise RuntimeError(f"gitlab 404: {url} (project/branch/path wrong or token lacks access)")
+        if r.status_code in (401, 403):
+            raise RuntimeError(f"gitlab auth error ({r.status_code}): {r.text[:200]}")
+        if r.status_code >= 400:
+            raise RuntimeError(f"gitlab error {r.status_code}: {r.text[:200]}")
+        return r
+
+    def latest_commit(self, project: str, branch: str) -> str:
+        r = self._get(f"/projects/{self._enc(project)}/repository/commits/{quote(branch, safe='')}")
+        return r.json()["id"]
+
+    def list_yaml_files(self, project: str, ref: str, path_prefix: str) -> list[str]:
+        """Repo-relative paths of *.yml/*.yaml under path_prefix at ref (paginated)."""
+        prefix = (path_prefix or "").strip("/")
+        out: list[str] = []
+        page = 1
+        while True:
+            r = self._get(
+                f"/projects/{self._enc(project)}/repository/tree",
+                params={"ref": ref, "recursive": "true", "per_page": 100,
+                        "page": page, **({"path": prefix} if prefix else {})},
+            )
+            entries = r.json()
+            for entry in entries:
+                if entry.get("type") != "blob":
+                    continue
+                p = entry["path"]
+                if p.lower().endswith(_YAML_EXT):
+                    out.append(p)
+            next_page = r.headers.get("x-next-page")
+            if not next_page:
+                break
+            page = int(next_page)
+        return out
+
+    def get_file(self, project: str, path: str, ref: str) -> str:
+        r = self._get(
+            f"/projects/{self._enc(project)}/repository/files/{quote(path, safe='')}/raw",
+            params={"ref": ref},
+        )
+        return r.text
+
+
+def _fetch_files_factory(api_base: str, token: str | None):
+    """Build a fetcher matching sync_repo's ``fetcher(repo_url, branch, path, token)``
+    contract, closing over the resolved GitLab api_base."""
+    def _fetch(repo_url, branch, path, token_ignored):
+        _, project = parse_gitlab_repo(repo_url, api_base)
+        with GitLabClient(api_base, token) as gl:
+            sha = gl.latest_commit(project, branch)
+            paths = gl.list_yaml_files(project, sha, path)
+            files = [(p, gl.get_file(project, p, sha)) for p in paths]
+        return sha, files
+    return _fetch
+
+
+def sync_integration(db, integration) -> dict:
+    """Run a Tests-as-Code sync for a gitlab-type integration."""
+    cfg = integration.config or {}
+    repo_url = cfg.get("repo_url")
+    if not repo_url:
+        raise ValueError("integration config missing 'repo_url'")
+    branch = cfg.get("branch") or "main"
+    path = cfg.get("path") or ""
+    token = cfg.get("token") or None
+    api_base, _ = parse_gitlab_repo(repo_url, cfg.get("api_base"))
+
+    stats = sync_repo(db, repo_url, branch, path, token,
+                      fetcher=_fetch_files_factory(api_base, token))
+
+    integration.last_sync = datetime.now(timezone.utc).isoformat()
+    integration.status = "active"
+    db.commit()
+    return stats

--- a/backend/routers/ci.py
+++ b/backend/routers/ci.py
@@ -18,6 +18,11 @@ from ..auth_utils import require_role
 from ..github_actions import (
     GitHubActionsClient, ci_config, pick_dispatched_run, collect_run_results,
 )
+from ..gitlab_actions import (
+    GitLabActionsClient, ci_config as gitlab_ci_config, collect_pipeline_results,
+    _TERMINAL as GITLAB_TERMINAL,
+)
+from ..vcs import detect_provider
 
 logger = logging.getLogger("thorotest.ci")
 router = APIRouter(tags=["ci"])
@@ -108,12 +113,80 @@ def _orchestrate(job_id: str, cfg: dict, since: datetime, run_name: Optional[str
         job["error"] = str(e)
 
 
+def _do_dispatch_gitlab(cfg: dict) -> dict:
+    with GitLabActionsClient(cfg["api_base"], cfg["token"]) as client:
+        return client.trigger_pipeline(cfg["project"], cfg["ref"])
+
+
+def _orchestrate_gitlab(job_id: str, cfg: dict, run_name: Optional[str]) -> None:
+    """Blocking: poll the pipeline until it finishes, then import its test
+    report. Runs in a worker thread."""
+    job = _JOBS[job_id]
+    pipeline_id = job["gl_pipeline_id"]
+    try:
+        with GitLabActionsClient(cfg["api_base"], cfg["token"]) as client:
+            job["status"] = "running"
+            deadline = time.time() + RUN_TIMEOUT
+            while time.time() < deadline:
+                detail = client.get_pipeline(cfg["project"], pipeline_id)
+                if detail.get("status") in GITLAB_TERMINAL:
+                    job["conclusion"] = detail.get("status")
+                    break
+                time.sleep(POLL_INTERVAL)
+            else:
+                raise RuntimeError("pipeline did not complete within timeout")
+
+            job["status"] = "collecting"
+            db = SessionLocal()
+            try:
+                stats = collect_pipeline_results(db, client, cfg["project"], pipeline_id, run_name)
+            finally:
+                db.close()
+
+            job["status"] = "done"
+            job["imported"] = stats
+    except Exception as e:
+        logger.warning("CI job %s failed: %s", job_id, e)
+        job["status"] = "error"
+        job["error"] = str(e)
+
+
 @router.post("/integrations/{intg_id}/ci/run")
 async def ci_run(intg_id: str, payload: CIRunRequest, db: Session = Depends(get_db), _: models.User = WRITE_ROLES):
-    """Dispatch a workflow and start collecting its results in the background."""
+    """Dispatch a workflow/pipeline and start collecting its results in the background."""
     intg = db.query(models.Integration).filter(models.Integration.id == intg_id).first()
     if not intg:
         raise HTTPException(status_code=404, detail="Integration not found")
+
+    try:
+        provider = detect_provider(intg.config or {})
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=f"Not a VCS integration: {e}")
+
+    if provider == "gitlab":
+        try:
+            cfg = gitlab_ci_config(intg)
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=f"Not a GitLab integration: {e}")
+        since = datetime.now(timezone.utc)
+        try:
+            pipeline = await asyncio.to_thread(_do_dispatch_gitlab, cfg)
+        except Exception as e:
+            raise HTTPException(status_code=502, detail=f"Dispatch failed: {e}")
+
+        job_id = uuid.uuid4().hex[:12]
+        _JOBS[job_id] = {
+            "id": job_id,
+            "integration_id": intg_id,
+            "workflow": "pipeline",
+            "ref": cfg["ref"],
+            "status": "running",
+            "started_at": since.isoformat(),
+            "gl_pipeline_id": pipeline.get("id"),
+            "gh_run_url": pipeline.get("web_url"),
+        }
+        asyncio.create_task(asyncio.to_thread(_orchestrate_gitlab, job_id, cfg, payload.run_name))
+        return {"job_id": job_id, "status": "dispatched", "workflow": "pipeline", "ref": cfg["ref"]}
 
     try:
         cfg = _resolve_cfg(intg, payload)

--- a/backend/routers/integrations.py
+++ b/backend/routers/integrations.py
@@ -6,7 +6,9 @@ from .. import models
 from ..schemas import IntegrationOut, IntegrationCreate, IntegrationUpdate
 from ..auth_utils import require_role, get_current_user
 from ..github_sync import sync_integration
+from ..gitlab_sync import sync_integration as sync_gitlab_integration
 from ..jira_sync import sync_jira_requirements
+from ..vcs import detect_provider
 
 router = APIRouter(tags=["integrations"])
 
@@ -68,6 +70,8 @@ def sync_integration_now(intg_id: str, db: Session = Depends(get_db), _: models.
     try:
         if intg.type == "jira":
             stats = sync_jira_requirements(db, intg)
+        elif detect_provider(intg.config or {}) == "gitlab":
+            stats = sync_gitlab_integration(db, intg)
         else:
             # sync_integration validates the config points at a github.com repo.
             stats = sync_integration(db, intg)

--- a/backend/tests/test_github_sync.py
+++ b/backend/tests/test_github_sync.py
@@ -163,13 +163,15 @@ def test_sync_endpoint(client, db, monkeypatch):
     assert db.query(models.Test).filter_by(id="TC-9").first() is not None
 
 
-def test_sync_endpoint_rejects_non_github_repo(client, db):
+def test_sync_endpoint_rejects_unknown_provider(client, db):
+    # A host that is neither github nor gitlab, with no explicit provider, can't
+    # be routed → 400. (gitlab.com is now a supported provider, see test_gitlab_sync.)
     db.add(models.Integration(
-        id="int-gl", name="GitLab", type="ci", icon="gitlab",
-        config={"repo_url": "https://gitlab.com/acme/web"},
+        id="int-unknown", name="Mystery", type="vcs_ci", icon="plug",
+        config={"repo_url": "https://example.com/acme/web"},
     ))
     db.commit()
-    r = client.post("/api/integrations/int-gl/sync")
+    r = client.post("/api/integrations/int-unknown/sync")
     assert r.status_code == 400
 
 

--- a/backend/tests/test_gitlab_actions.py
+++ b/backend/tests/test_gitlab_actions.py
@@ -1,0 +1,75 @@
+"""GitLab CI collection logic (no network — fake client / crafted report)."""
+from backend import models
+from backend.gitlab_actions import (
+    parse_test_report, collect_pipeline_results, ci_config,
+)
+
+
+_REPORT = {
+    "total_count": 3,
+    "test_suites": [
+        {"name": "e2e", "test_cases": [
+            {"name": "login works", "classname": "e2e.auth", "status": "success"},
+            {"name": "checkout fails", "classname": "e2e.checkout", "status": "failed"},
+        ]},
+        {"name": "unit", "test_cases": [
+            {"name": "skipped one", "classname": "unit.misc", "status": "skipped"},
+        ]},
+    ],
+}
+
+
+def test_report_maps_statuses_and_folders():
+    result = parse_test_report(_REPORT, "GL #7")
+    assert result.format_detected == "gitlab_test_report"
+    assert len(result.tests) == 3
+    statuses = {c.test_title: c.status for c in result.runs[0].cases}
+    assert statuses == {"login works": "pass", "checkout fails": "fail", "skipped one": "blocked"}
+    folders = {t.title: t.folder_path for t in result.tests}
+    assert folders["login works"] == "e2e/auth"
+
+
+class _FakeClient:
+    def get_test_report(self, project, pipeline_id):
+        assert pipeline_id == 42
+        return _REPORT
+
+
+def test_collect_pipeline_results_imports(db):
+    stats = collect_pipeline_results(db, _FakeClient(), "acme/web", 42, "GL pipeline 42")
+    assert stats["tests"] == 3 and stats["runs"] == 1
+
+    run = db.query(models.Run).filter(models.Run.name == "GL pipeline 42").first()
+    assert run is not None
+    assert run.passed == 1 and run.failed == 1 and run.blocked == 1
+
+
+def test_ci_config_derives_project_and_api_base():
+    intg = models.Integration(
+        id="i", name="GL", type="vcs_ci", icon="gitlab",
+        config={"provider": "gitlab", "repo_url": "http://localhost:8929/root/app",
+                "branch": "dev", "token": "glpat-x"},
+    )
+    cfg = ci_config(intg)
+    assert cfg["api_base"] == "http://localhost:8929/api/v4"
+    assert cfg["project"] == "root/app"
+    assert cfg["ref"] == "dev"
+    assert cfg["token"] == "glpat-x"
+
+
+def test_ci_run_dispatches_gitlab(client, db, monkeypatch):
+    from backend.routers import ci as ci_router
+    monkeypatch.setattr(ci_router, "_do_dispatch_gitlab", lambda cfg: {"id": 99, "web_url": "http://x/99"})
+    monkeypatch.setattr(ci_router, "_orchestrate_gitlab", lambda *a, **k: None)
+
+    db.add(models.Integration(
+        id="int-gl-ci", name="GitLab", type="vcs_ci", icon="gitlab",
+        config={"provider": "gitlab", "repo_url": "https://gitlab.com/acme/web",
+                "branch": "main", "token": "glpat-x"},
+    ))
+    db.commit()
+    r = client.post("/api/integrations/int-gl-ci/ci/run", json={})
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["status"] == "dispatched"
+    assert body["workflow"] == "pipeline"

--- a/backend/tests/test_gitlab_sync.py
+++ b/backend/tests/test_gitlab_sync.py
@@ -1,0 +1,111 @@
+import pytest
+
+from backend import models, gitlab_sync
+from backend.vcs import detect_provider
+
+
+# ── repo url parsing ────────────────────────────────────────────
+
+@pytest.mark.parametrize("url,api_base,project", [
+    ("https://gitlab.com/acme/web", "https://gitlab.com/api/v4", "acme/web"),
+    ("https://gitlab.com/acme/web.git", "https://gitlab.com/api/v4", "acme/web"),
+    ("https://gitlab.com/acme/web/", "https://gitlab.com/api/v4", "acme/web"),
+    ("https://gitlab.com/grp/sub/web", "https://gitlab.com/api/v4", "grp/sub/web"),
+    ("http://localhost:8929/root/thorotest", "http://localhost:8929/api/v4", "root/thorotest"),
+    ("git@gitlab.com:acme/web.git", "https://gitlab.com/api/v4", "acme/web"),
+])
+def test_parse_gitlab_repo(url, api_base, project):
+    assert gitlab_sync.parse_gitlab_repo(url) == (api_base, project)
+
+
+def test_parse_gitlab_repo_api_base_override():
+    api, proj = gitlab_sync.parse_gitlab_repo(
+        "http://gitlab.internal/root/app", api_base="http://api.internal/api/v4")
+    assert api == "http://api.internal/api/v4"
+    assert proj == "root/app"
+
+
+def test_parse_gitlab_repo_rejects_bad_url():
+    with pytest.raises(ValueError):
+        gitlab_sync.parse_gitlab_repo("https://gitlab.com/no-project")
+
+
+# ── provider detection ──────────────────────────────────────────
+
+def test_detect_provider_explicit():
+    assert detect_provider({"provider": "gitlab", "repo_url": "http://x/y/z"}) == "gitlab"
+
+
+def test_detect_provider_infers_host():
+    assert detect_provider({"repo_url": "https://gitlab.com/a/b"}) == "gitlab"
+    assert detect_provider({"repo_url": "https://github.com/a/b"}) == "github"
+
+
+def test_detect_provider_self_hosted_needs_explicit():
+    with pytest.raises(ValueError):
+        detect_provider({"repo_url": "http://localhost:8929/root/app"})
+
+
+# ── sync_integration (fake GitLabClient, no network) ────────────
+
+class _FakeGL:
+    """Stand-in for GitLabClient: serves a fixed tree + file contents."""
+    tree = ["e2e/login.yml", "e2e/checkout.yaml", "README.md"]
+    files = {
+        "e2e/login.yml": 'id: TC-GL1\ntitle: "GL login"\ntype: automated\nrunner: playwright\nfolder: E2E/Auth\n',
+        "e2e/checkout.yaml": 'title: "GL checkout"\ntype: manual\n',
+    }
+
+    def __init__(self, *a, **k):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        pass
+
+    def latest_commit(self, project, branch):
+        return "sha-gl-123"
+
+    def list_yaml_files(self, project, ref, path_prefix):
+        return [p for p in self.tree if p.lower().endswith((".yml", ".yaml"))]
+
+    def get_file(self, project, path, ref):
+        return self.files[path]
+
+
+def test_gitlab_sync_integration_creates_tests(db, monkeypatch):
+    monkeypatch.setattr(gitlab_sync, "GitLabClient", _FakeGL)
+    intg = models.Integration(
+        id="int-gitlab", name="GitLab", type="vcs_ci", icon="gitlab",
+        config={"provider": "gitlab", "repo_url": "https://gitlab.com/acme/web",
+                "branch": "main", "path": "e2e/", "token": "glpat-x"},
+    )
+    db.add(intg)
+    db.commit()
+
+    stats = gitlab_sync.sync_integration(db, intg)
+    assert stats["created"] == 2
+    assert stats["commit"] == "sha-gl-123"
+
+    t = db.query(models.Test).filter_by(id="TC-GL1").first()
+    assert t is not None
+    assert t.repo_url == "https://gitlab.com/acme/web"
+    assert t.source_path == "e2e/login.yml"
+    assert t.source_ref == "sha-gl-123"
+    assert t.folder_rel is not None and t.folder_rel.name == "Auth"
+
+
+def test_gitlab_sync_endpoint(client, db, monkeypatch):
+    monkeypatch.setattr(gitlab_sync, "GitLabClient", _FakeGL)
+    db.add(models.Integration(
+        id="int-gl-ep", name="GitLab", type="vcs_ci", icon="gitlab",
+        config={"provider": "gitlab", "repo_url": "https://gitlab.com/acme/web",
+                "branch": "main", "path": "e2e/", "token": "glpat-x"},
+    ))
+    db.commit()
+    r = client.post("/api/integrations/int-gl-ep/sync")
+    assert r.status_code == 200, r.text
+    assert r.json()["created"] == 2
+    assert db.query(models.Test).filter_by(id="TC-GL1").first() is not None

--- a/backend/vcs.py
+++ b/backend/vcs.py
@@ -1,0 +1,32 @@
+"""VCS provider detection shared by the sync and CI routers.
+
+An integration's provider is either set explicitly in its config
+(``{"provider": "github" | "gitlab"}``) or inferred from the repo URL host.
+Self-hosted GitLab (arbitrary host, e.g. ``localhost:8929``) can't be inferred,
+so those integrations must set ``provider`` explicitly.
+"""
+from urllib.parse import urlsplit
+
+PROVIDERS = ("github", "gitlab")
+
+
+def detect_provider(cfg: dict) -> str:
+    """Return "github" or "gitlab" for a VCS integration config. Raises
+    ValueError when neither an explicit provider nor a recognisable host is
+    present."""
+    cfg = cfg or {}
+    explicit = (cfg.get("provider") or "").strip().lower()
+    if explicit in PROVIDERS:
+        return explicit
+
+    host = urlsplit((cfg.get("repo_url") or "").strip()).hostname or ""
+    # git@host:org/repo has no scheme; fall back to a substring check.
+    raw = (cfg.get("repo_url") or "").lower()
+    if "github.com" in (host or raw):
+        return "github"
+    if "gitlab.com" in (host or raw):
+        return "gitlab"
+    raise ValueError(
+        "cannot determine VCS provider: set config.provider to 'github' or "
+        "'gitlab' (required for self-hosted hosts)"
+    )

--- a/e2e/suite-p16-github-sync/github-sync.spec.ts
+++ b/e2e/suite-p16-github-sync/github-sync.spec.ts
@@ -104,20 +104,22 @@ test.describe('Suite P16 — Tests as Code (GitHub sync)', () => {
     await cleanupGithub(page, token);
   });
 
-  // GHS-04 · Sync against a non-github repo surfaces an error in the UI [P1]
-  test('GHS-04: sync of a non-github repo shows an error message', async ({ page }) => {
+  // GHS-04 · Sync against an unroutable repo surfaces an error in the UI [P1]
+  // (github.com and gitlab.com are both supported now; an unknown host with no
+  // explicit provider can't be routed → 400.)
+  test('GHS-04: sync of an unroutable repo shows an error message', async ({ page }) => {
     await loginAs(page, 'marco@acme.com');
     const token = await getToken(page);
     await cleanupGithub(page, token);
 
-    const id = `int-e2e-ghs-gl-${Date.now()}`;
+    const id = `int-e2e-ghs-unknown-${Date.now()}`;
     await page.request.post(`${BASE}/api/integrations`, {
       data: { id, name: 'GitHub', type: 'vcs_ci', icon: 'github',
-              config: { repo_url: 'https://gitlab.com/acme/web-e2e-ghs', branch: 'main', path: '' } },
+              config: { repo_url: 'https://example.com/acme/web-e2e-ghs', branch: 'main', path: '' } },
       headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
     });
 
-    // API contract: non-github repo → 400
+    // API contract: unknown provider → 400
     const apiSync = await page.request.post(`${BASE}/api/integrations/${id}/sync`, { headers: { Authorization: `Bearer ${token}` } });
     expect(apiSync.status()).toBe(400);
 
@@ -125,7 +127,7 @@ test.describe('Suite P16 — Tests as Code (GitHub sync)', () => {
     await page.goto('/#/integrations');
     const row = page.locator('tr').filter({ hasText: 'GitHub' }).filter({ has: page.locator('button:has-text("Sync")') }).first();
     await row.locator('button:has-text("Sync")').click();
-    await expect(row.locator('text=/github repo url/i')).toBeVisible({ timeout: 8000 });
+    await expect(row.locator('text=/provider/i')).toBeVisible({ timeout: 8000 });
 
     await cleanupGithub(page, token);
   });

--- a/frontend/views/view-config.jsx
+++ b/frontend/views/view-config.jsx
@@ -2,7 +2,7 @@
 
 const PROVIDERS = [
   { id: "github",     name: "GitHub",      icon: "github",  type: "vcs_ci",        configuredBy: "" },
-  { id: "gitlab",     name: "GitLab CI",   icon: "gitlab",  type: "ci",            configuredBy: "external runner" },
+  { id: "gitlab",     name: "GitLab",      icon: "gitlab",  type: "vcs_ci",        configuredBy: "" },
   { id: "jenkins",    name: "Jenkins",     icon: "jenkins", type: "ci",            configuredBy: "" },
   { id: "playwright", name: "Playwright",  icon: "plug",    type: "runner",        configuredBy: "playwright.config.ts" },
   { id: "cypress",    name: "Cypress",     icon: "plug",    type: "runner",        configuredBy: "cypress.config.js" },
@@ -31,15 +31,21 @@ const MODAL_BOX = {
   maxHeight: "90vh", overflowY: "auto",
 };
 
-function GithubConfigFields({ form, setForm, tokenSet }) {
+function VcsConfigFields({ form, setForm, tokenSet, provider = "github" }) {
   const fld = { marginBottom:12 };
   const lbl = { display:"block", fontSize:12, fontWeight:500, color:"var(--text-muted)", marginBottom:6 };
   const set = (k) => (e) => setForm(f => ({ ...f, [k]: e.target.value }));
+  const isGitlab = provider === "gitlab";
+  const repoPlaceholder = isGitlab ? "https://gitlab.com/group/repo" : "https://github.com/org/repo";
+  const tokenHint = tokenSet ? "(leave blank to keep current)"
+    : isGitlab ? "(private repos + Run CI need the api scope)"
+               : "(private repos + Run CI need the actions scope)";
+  const tokenPlaceholder = tokenSet ? "••••••••" : isGitlab ? "glpat-…" : "ghp_…";
   return (
     <>
       <div style={fld}>
         <label style={lbl}>Repository URL</label>
-        <input className="login-input" value={form.repo_url} onChange={set("repo_url")} placeholder="https://github.com/org/repo" style={{width:"100%"}} />
+        <input className="login-input" value={form.repo_url} onChange={set("repo_url")} placeholder={repoPlaceholder} style={{width:"100%"}} />
       </div>
       <div style={{display:"flex", gap:8}}>
         <div style={{...fld, flex:1}}>
@@ -52,19 +58,26 @@ function GithubConfigFields({ form, setForm, tokenSet }) {
         </div>
       </div>
       <div style={fld}>
-        <label style={lbl}>Personal access token {tokenSet ? "(leave blank to keep current)" : "(private repos + Run CI need the actions scope)"}</label>
-        <input className="login-input" type="password" value={form.token} onChange={set("token")} placeholder={tokenSet ? "••••••••" : "ghp_…"} autoComplete="off" style={{width:"100%"}} />
+        <label style={lbl}>Personal access token {tokenHint}</label>
+        <input className="login-input" type="password" value={form.token} onChange={set("token")} placeholder={tokenPlaceholder} autoComplete="off" style={{width:"100%"}} />
       </div>
-      <div style={{display:"flex", gap:8}}>
-        <div style={{...fld, flex:1}}>
-          <label style={lbl}>Workflow (for Run CI)</label>
-          <input className="login-input" value={form.workflow || ""} onChange={set("workflow")} placeholder="ci.yml" style={{width:"100%"}} />
+      {isGitlab ? (
+        <div style={fld}>
+          <label style={lbl}>API base URL (self-hosted only — leave blank for gitlab.com)</label>
+          <input className="login-input" value={form.api_base || ""} onChange={set("api_base")} placeholder="http://localhost:8929/api/v4" style={{width:"100%"}} />
         </div>
-        <div style={{...fld, flex:1}}>
-          <label style={lbl}>JUnit artifact name</label>
-          <input className="login-input" value={form.junit_artifact || ""} onChange={set("junit_artifact")} placeholder="junit" style={{width:"100%"}} />
+      ) : (
+        <div style={{display:"flex", gap:8}}>
+          <div style={{...fld, flex:1}}>
+            <label style={lbl}>Workflow (for Run CI)</label>
+            <input className="login-input" value={form.workflow || ""} onChange={set("workflow")} placeholder="ci.yml" style={{width:"100%"}} />
+          </div>
+          <div style={{...fld, flex:1}}>
+            <label style={lbl}>JUnit artifact name</label>
+            <input className="login-input" value={form.junit_artifact || ""} onChange={set("junit_artifact")} placeholder="junit" style={{width:"100%"}} />
+          </div>
         </div>
-      </div>
+      )}
     </>
   );
 }
@@ -109,7 +122,7 @@ function IntRow({ intg, onEdit, onDelete, onSync }) {
   const [ciMsg, setCiMsg] = React.useState(null);
   const menuRef = React.useRef(null);
   const canSync = !!(intg.config && (intg.config.repo_url || (intg.type === "jira" && intg.config.base_url)));
-  const isGithub = !!(intg.config && intg.config.repo_url) && intg.type !== "jira";
+  const isVcs = !!(intg.config && intg.config.repo_url) && intg.type !== "jira";
 
   const doSync = async () => {
     setSyncing(true); setSyncMsg(null);
@@ -171,8 +184,8 @@ function IntRow({ intg, onEdit, onDelete, onSync }) {
         {ciMsg && <div style={{fontSize:10.5, color: ciMsg.ok ? "var(--accent)" : "var(--fail)"}}>CI: {ciMsg.text}</div>}
       </td>
       <td style={{position:"relative", textAlign:"right", whiteSpace:"nowrap"}} ref={menuRef}>
-        {isGithub && (
-          <button className="btn sm" style={{marginRight:6}} disabled={ciBusy} onClick={doCI} title="Dispatch the GitHub Actions workflow and import its results">
+        {isVcs && (
+          <button className="btn sm" style={{marginRight:6}} disabled={ciBusy} onClick={doCI} title="Trigger the CI pipeline and import its results">
             {ciBusy ? "Running…" : "Run CI"}
           </button>
         )}
@@ -219,14 +232,14 @@ function AddIntegrationModal({ onClose, onSaved, existingIds }) {
   const [err, setErr] = React.useState(null);
   useEscapeClose(onClose);
 
-  const isGithub = provider?.id === "github";
+  const isVcs = provider?.id === "github" || provider?.id === "gitlab";
   const isJira = provider?.id === "jira";
 
   const pick = (p) => {
     setProvider(p);
     setForm({
       configured_by: p.configuredBy, repo_url: "", branch: "main", path: "", token: "",
-      workflow: "ci.yml", junit_artifact: "junit",
+      workflow: "ci.yml", junit_artifact: "junit", api_base: "",
       base_url: "", email: "", api_token: "", project_key: "", issue_type_bug: "Bug",
     });
     setStep("configure");
@@ -240,15 +253,21 @@ function AddIntegrationModal({ onClose, onSaved, existingIds }) {
         id, name: provider.name, type: provider.type, icon: provider.icon,
         configured_by: form.configured_by || null, last_sync: null,
       };
-      if (isGithub) {
+      if (isVcs) {
         payload.config = {
+          provider: provider.id,
           repo_url: form.repo_url.trim(),
           branch: form.branch.trim() || "main",
           path: form.path.trim(),
           token: form.token.trim(),
-          workflow: (form.workflow || "").trim() || "ci.yml",
-          junit_artifact: (form.junit_artifact || "").trim() || "junit",
         };
+        if (provider.id === "gitlab") {
+          const apiBase = (form.api_base || "").trim();
+          if (apiBase) payload.config.api_base = apiBase;
+        } else {
+          payload.config.workflow = (form.workflow || "").trim() || "ci.yml";
+          payload.config.junit_artifact = (form.junit_artifact || "").trim() || "junit";
+        }
       } else if (isJira) {
         payload.config = {
           base_url: form.base_url.trim(),
@@ -306,7 +325,7 @@ function AddIntegrationModal({ onClose, onSaved, existingIds }) {
                 style={{width:"100%"}}
               />
             </div>
-            {isGithub && <GithubConfigFields form={form} setForm={setForm} tokenSet={false} />}
+            {isVcs && <VcsConfigFields form={form} setForm={setForm} tokenSet={false} provider={provider.id} />}
             {isJira && <JiraConfigFields form={form} setForm={setForm} tokenSet={false} />}
             {err && <div style={{fontSize:12, color:"var(--fail)", marginBottom:8}}>{err}</div>}
             <div style={{display:"flex", gap:8}}>
@@ -323,14 +342,16 @@ function AddIntegrationModal({ onClose, onSaved, existingIds }) {
 function EditIntegrationModal({ intg, onClose, onSaved }) {
   useEscapeClose(onClose);
   const cfg = intg.config || {};
-  const isGithub = intg.icon === "github" || !!cfg.repo_url;
   const isJira = intg.type === "jira";
+  const providerId = cfg.provider || (intg.icon === "gitlab" ? "gitlab" : "github");
+  const isVcs = !isJira && (!!cfg.repo_url || intg.icon === "github" || intg.icon === "gitlab");
   const tokenSet = !!cfg.token_set;
   const apiTokenSet = !!cfg.api_token_set;
   const [form, setForm] = React.useState({
     name: intg.name, configured_by: intg.configured_by || "", status: intg.status,
     repo_url: cfg.repo_url || "", branch: cfg.branch || "main", path: cfg.path || "", token: "",
     workflow: cfg.workflow || "ci.yml", junit_artifact: cfg.junit_artifact || "junit",
+    api_base: cfg.api_base || "",
     base_url: cfg.base_url || "", email: cfg.email || "", api_token: "",
     project_key: cfg.project_key || "", issue_type_bug: cfg.issue_type_bug || "Bug",
   });
@@ -343,16 +364,21 @@ function EditIntegrationModal({ intg, onClose, onSaved }) {
       const payload = {
         name: form.name, configured_by: form.configured_by || null, status: form.status,
       };
-      if (isGithub) {
+      if (isVcs) {
         // Empty token is preserved server-side (token is never wiped by a blank field).
         payload.config = {
+          provider: providerId,
           repo_url: form.repo_url.trim(),
           branch: form.branch.trim() || "main",
           path: form.path.trim(),
           token: form.token.trim(),
-          workflow: (form.workflow || "").trim() || "ci.yml",
-          junit_artifact: (form.junit_artifact || "").trim() || "junit",
         };
+        if (providerId === "gitlab") {
+          payload.config.api_base = (form.api_base || "").trim();
+        } else {
+          payload.config.workflow = (form.workflow || "").trim() || "ci.yml";
+          payload.config.junit_artifact = (form.junit_artifact || "").trim() || "junit";
+        }
       } else if (isJira) {
         // Empty api_token is preserved server-side (never wiped by a blank field).
         payload.config = {
@@ -389,7 +415,7 @@ function EditIntegrationModal({ intg, onClose, onSaved }) {
             <option value="error">Error</option>
           </select>
         </div>
-        {isGithub && <GithubConfigFields form={form} setForm={setForm} tokenSet={tokenSet} />}
+        {isVcs && <VcsConfigFields form={form} setForm={setForm} tokenSet={tokenSet} provider={providerId} />}
         {isJira && <JiraConfigFields form={form} setForm={setForm} tokenSet={apiTokenSet} />}
         {err && <div style={{fontSize:12, color:"var(--fail)", marginBottom:8}}>{err}</div>}
         <div style={{display:"flex", gap:8}}>


### PR DESCRIPTION
## What

Adds **GitLab** as a first-class VCS provider alongside GitHub, for both
**Tests-as-Code sync** and **CI triggering** — works against gitlab.com and
self-hosted instances. Until now GitLab was cosmetic-only (a seed row + icon,
no backing logic).

## How

- **`backend/vcs.py`** — `detect_provider(cfg)` routes a VCS integration by an
  explicit `config.provider` or the inferred repo host (self-hosted requires
  explicit provider).
- **`backend/gitlab_sync.py`** — `GitLabClient` (REST v4, `PRIVATE-TOKEN`,
  paginated tree) + a GitLab fetcher injected into the existing
  `github_sync.sync_repo`, so folder-tree building, source-link recording and
  idempotent upsert are shared, not duplicated.
- **`backend/gitlab_actions.py`** — trigger a pipeline
  (`POST /projects/:id/pipeline` returns the id, so no "find the run" step) →
  poll to a terminal status → import the structured `test_report` JSON
  (`parse_test_report` → `ImportResult` → shared `persist_import_result`).
- **Routers** — `/integrations/:id/sync` and `/integrations/:id/ci/run` branch
  by detected provider.
- **Frontend** — `GithubConfigFields` generalized to `VcsConfigFields`
  (provider-aware): GitLab shows an optional self-hosted API base URL and hints
  the `api` token scope, instead of the GitHub workflow/artifact fields. Add /
  Edit modals persist `config.provider`; Run CI / Sync are provider-neutral.

## Tests

- New: repo-url parsing, provider detection, `test_report` status/folder
  mapping, `collect_pipeline_results`, GitLab CI dispatch, GitLab sync endpoint.
- The old "reject non-github sync" test was rewritten around an unknown host,
  since gitlab.com is now a supported provider.
- **Full backend suite: 535 passed.**
- Frontend verified with a Playwright smoke drive (GitLab config renders the
  api_base field, hides the GitHub-only fields, Run CI appears after config, no
  console errors).

## Follow-up (not in this PR)

Local GitLab CE (Docker) + runner + a demo repo with `.gitlab-ci.yml`, plus a
proper `vcs_ci` GitLab seed row, to demo the integration end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)