### PR TITLE
feat(gitlab): local GitLab CE demo + vcs_ci seed row (v1.5.0)

### DIFF
--- a/backend/seed.py
+++ b/backend/seed.py
@@ -215,7 +215,7 @@ def seed_db():
 
         integrations = [
             models.Integration(id="int-github", name="GitHub", type="vcs_ci", icon="github", status="active", configured_by="acme/web · main", last_sync="just now"),
-            models.Integration(id="int-gitlab", name="GitLab CI", type="ci", icon="gitlab", status="active", configured_by="external runner", last_sync="3m ago"),
+            models.Integration(id="int-gitlab", name="GitLab", type="vcs_ci", icon="gitlab", status="active", configured_by="acme/web · main", last_sync="5m ago"),
             models.Integration(id="int-jenkins", name="Jenkins", type="ci", icon="jenkins", status="active", configured_by="ci.acme.test", last_sync="1h ago"),
             models.Integration(id="int-playwright", name="Playwright", type="runner", icon="plug", status="active", configured_by="playwright.config.ts", last_sync="12m ago"),
             models.Integration(id="int-cypress", name="Cypress", type="runner", icon="plug", status="active", configured_by="cypress.config.js", last_sync="10m ago"),

--- a/demo/gitlab/README.md
+++ b/demo/gitlab/README.md
@@ -1,0 +1,69 @@
+# Local GitLab demo for the ThoroTest GitLab integration
+
+Spins up a real, self-hosted **GitLab CE** + a **docker-executor runner** so you
+can demo ThoroTest's GitLab integration end-to-end against a live instance:
+
+- **Tests-as-Code sync** — pull YAML test definitions from the repo.
+- **Run CI** — trigger a pipeline, wait for it, and import its `test_report`
+  (pytest + Playwright jobs) as a ThoroTest run.
+
+## Prerequisites
+
+- Docker Desktop (allow it ~4 GB RAM; the GitLab CE image is amd64 and runs
+  under emulation on Apple Silicon — first boot takes a few minutes).
+
+## Bring it up
+
+```bash
+cd demo/gitlab
+docker compose up -d      # GitLab CE + runner
+./setup.sh                # waits for the API, then provisions everything
+```
+
+`setup.sh` is idempotent-ish and:
+
+1. mints a root PAT (scope `api`),
+2. creates the `thorotest-demo` project and pushes [`repo/`](repo/)
+   (YAML tests under `tests/` + a `.gitlab-ci.yml` with `pytest` and
+   `playwright` jobs),
+3. creates an instance runner and registers it (docker executor).
+
+It prints the values to paste into a ThoroTest GitLab integration:
+
+```
+provider : gitlab
+repo_url : http://localhost:8929/root/thorotest-demo
+api_base : http://localhost:8929/api/v4
+branch   : main
+path     : tests/
+token    : glpat-…
+```
+
+- GitLab web UI: <http://localhost:8929>  (login `root` / `thorotest-demo-1234`)
+
+## The demo pipeline
+
+[`repo/.gitlab-ci.yml`](repo/.gitlab-ci.yml) runs two jobs, each publishing a
+JUnit report (`artifacts: reports: junit:`, `when: always`):
+
+- **pytest** — [`repo/ci_tests/`](repo/ci_tests/), all green.
+- **playwright** — [`repo/e2e/`](repo/e2e/), one intentional failure.
+
+So the pipeline goes **red** (playwright fails), yet ThoroTest still imports the
+full breakdown — **5 pass / 1 fail** — because the reports publish even on
+failure. Change the assertions to make it all green, or move the failure between
+jobs, to reshape the demo.
+
+## Networking note
+
+The browser and ThoroTest reach GitLab at `http://localhost:8929`, but the
+runner (and its job containers) reach it as `http://gitlab:8929` over the
+compose network. `setup.sh` registers the runner with
+`--clone-url http://gitlab:8929` so job git-clones resolve correctly without any
+host `/etc/hosts` edits.
+
+## Tear down
+
+```bash
+docker compose down -v    # removes containers AND volumes (full reset)
+```

--- a/demo/gitlab/docker-compose.yml
+++ b/demo/gitlab/docker-compose.yml
@@ -1,0 +1,54 @@
+# Local GitLab CE + a docker-executor runner, for demoing ThoroTest's GitLab
+# integration end-to-end (Tests-as-Code sync + Run CI → test_report import).
+#
+#   cd demo/gitlab && docker compose up -d      # ~4GB RAM, first boot 3-5 min
+#   ./setup.sh                                   # project + repo + runner + token
+#
+# Web/API: http://localhost:8929   (external_url must match the port).
+name: thorotest-gitlab-demo
+
+services:
+  gitlab:
+    image: gitlab/gitlab-ce:17.5.1-ce.0
+    hostname: localhost
+    restart: unless-stopped
+    environment:
+      GITLAB_OMNIBUS_CONFIG: |
+        external_url 'http://localhost:8929'
+        gitlab_rails['initial_root_password'] = 'thorotest-demo-1234'
+        gitlab_rails['gitlab_shell_ssh_port'] = 2224
+        # Trim memory footprint for a laptop demo.
+        puma['worker_processes'] = 2
+        sidekiq['max_concurrency'] = 6
+        prometheus_monitoring['enable'] = false
+        gitlab_rails['gitlab_default_projects_features_container_registry'] = false
+    ports:
+      - "8929:8929"
+      - "2224:2224"
+    shm_size: "256m"
+    volumes:
+      - gitlab-config:/etc/gitlab
+      - gitlab-logs:/var/log/gitlab
+      - gitlab-data:/var/opt/gitlab
+    healthcheck:
+      test: ["CMD", "/opt/gitlab/bin/gitlab-healthcheck", "--fail", "--max-time", "10"]
+      interval: 30s
+      timeout: 15s
+      retries: 30
+      start_period: 300s
+
+  runner:
+    image: gitlab/gitlab-runner:v17.5.1
+    restart: unless-stopped
+    depends_on:
+      - gitlab
+    volumes:
+      - runner-config:/etc/gitlab-runner
+      # docker executor talks to the host Docker daemon.
+      - /var/run/docker.sock:/var/run/docker.sock
+
+volumes:
+  gitlab-config:
+  gitlab-logs:
+  gitlab-data:
+  runner-config:

--- a/demo/gitlab/repo/.gitlab-ci.yml
+++ b/demo/gitlab/repo/.gitlab-ci.yml
@@ -1,0 +1,28 @@
+# Demo pipeline: a backend (pytest) job and an e2e (Playwright) job, each
+# publishing a JUnit report. GitLab merges both into the pipeline's test_report,
+# which ThoroTest's "Run CI" imports as one run. `artifacts: when: always` keeps
+# the reports flowing even when a job goes red, so the pass/fail breakdown still
+# reaches ThoroTest.
+stages: [test]
+
+pytest:
+  image: python:3.12-slim
+  stage: test
+  script:
+    - pip install --quiet pytest
+    - pytest ci_tests/ --junitxml=report.xml
+  artifacts:
+    when: always
+    reports:
+      junit: report.xml
+
+playwright:
+  image: mcr.microsoft.com/playwright:v1.49.0-jammy
+  stage: test
+  script:
+    - npm install --no-save @playwright/test@1.49.0
+    - npx playwright test
+  artifacts:
+    when: always
+    reports:
+      junit: e2e-report.xml

--- a/demo/gitlab/repo/ci_tests/test_checkout.py
+++ b/demo/gitlab/repo/ci_tests/test_checkout.py
@@ -1,0 +1,16 @@
+"""Demo backend suite run by the GitLab pipeline's `pytest` job — all green.
+The intentional failure lives in the Playwright (e2e) job instead, so the demo
+shows which job/suite went red."""
+
+
+def test_login_with_valid_credentials():
+    assert 1 + 1 == 2
+
+
+def test_promo_code_applies():
+    discount = 0.10
+    assert round(100 * (1 - discount), 2) == 90.00
+
+
+def test_password_reset_email_sent():
+    assert "sent" == "sent"

--- a/demo/gitlab/repo/e2e/checkout.spec.ts
+++ b/demo/gitlab/repo/e2e/checkout.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from '@playwright/test';
+
+// Pure-assertion e2e demo (no app/browser needed) so the pipeline is fast and
+// deterministic. One test fails on purpose → the playwright job goes red while
+// the pytest job stays green.
+test.describe('checkout', () => {
+  test('guest checkout succeeds', async () => {
+    expect(200).toBe(200);
+  });
+
+  test('promo code applies discount', async () => {
+    const total = 100 * (1 - 0.1);
+    expect(total).toBeCloseTo(90);
+  });
+
+  test('apple pay sheet opens on Safari iOS', async () => {
+    // Intentional failure — demonstrates a red e2e result flowing into ThoroTest.
+    const sheet = 'closed';
+    expect(sheet).toBe('opened');
+  });
+});

--- a/demo/gitlab/repo/package.json
+++ b/demo/gitlab/repo/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "thorotest-gitlab-demo",
+  "private": true,
+  "version": "1.0.0",
+  "devDependencies": {
+    "@playwright/test": "1.49.0"
+  }
+}

--- a/demo/gitlab/repo/playwright.config.ts
+++ b/demo/gitlab/repo/playwright.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from '@playwright/test';
+
+// Emit a JUnit report so the GitLab pipeline's test_report (and ThoroTest's
+// import) picks up the e2e results alongside the pytest ones.
+export default defineConfig({
+  testDir: './e2e',
+  reporter: [
+    ['list'],
+    ['junit', { outputFile: 'e2e-report.xml' }],
+  ],
+});

--- a/demo/gitlab/repo/tests/auth/login.yml
+++ b/demo/gitlab/repo/tests/auth/login.yml
@@ -1,0 +1,9 @@
+id: TC-GL-100
+title: "Login with valid credentials"
+type: e2e
+runner: playwright
+status: passed
+priority: P1
+owner: qa@acme.com
+tags: [smoke, auth]
+folder: E2E/Auth

--- a/demo/gitlab/repo/tests/checkout/promo.yml
+++ b/demo/gitlab/repo/tests/checkout/promo.yml
@@ -1,0 +1,9 @@
+id: TC-GL-101
+title: "Promo code applies discount at checkout"
+type: e2e
+runner: playwright
+status: pending
+priority: P2
+owner: qa@acme.com
+tags: [checkout, payment]
+folder: E2E/Checkout

--- a/demo/gitlab/setup.sh
+++ b/demo/gitlab/setup.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Provision the local GitLab CE for the ThoroTest demo:
+#   1. wait for the API to come up
+#   2. mint a root PAT (scope: api)
+#   3. create the demo project and push repo/ (YAML tests + .gitlab-ci.yml)
+#   4. create an instance runner + register the docker-executor runner
+#
+# Run AFTER `docker compose up -d`, from this directory:
+#   ./setup.sh
+#
+# Networking note: browser/ThoroTest reach GitLab at http://localhost:8929,
+# but the runner and its job containers reach it as http://gitlab:8929 (compose
+# DNS). We register the runner with --clone-url http://gitlab:8929 so job git
+# clones don't try to hit localhost inside the container.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+WEB="http://localhost:8929"
+API="$WEB/api/v4"
+INTERNAL_URL="http://gitlab:8929"
+NETWORK="thorotest-gitlab-demo_default"
+ROOT_PW="thorotest-demo-1234"
+PROJECT="thorotest-demo"
+
+dc() { docker compose "$@"; }
+
+echo "==> waiting for GitLab API (first boot can take 3-5 min)…"
+for i in $(seq 1 60); do
+  code=$(curl -s -o /dev/null -w "%{http_code}" "$API/version" || true)
+  # 401 = up but unauthenticated (expected before we have a token)
+  if [ "$code" = "401" ] || [ "$code" = "200" ]; then echo "    GitLab is up."; break; fi
+  printf '.'; sleep 10
+  if [ "$i" = "60" ]; then echo "GitLab did not come up in time"; exit 1; fi
+done
+
+echo "==> minting a root PAT (scope: api) via gitlab-rails…"
+TOKEN=$(dc exec -T gitlab gitlab-rails runner "
+  u = User.find_by_username('root')
+  u.personal_access_tokens.where(name: 'thorotest-demo').destroy_all
+  t = u.personal_access_tokens.create!(scopes: ['api'], name: 'thorotest-demo', expires_at: 365.days.from_now)
+  puts t.token
+" | tr -d '\r' | tail -n1)
+echo "    token: ${TOKEN:0:12}…"
+
+echo "==> creating project '$PROJECT' (idempotent)…"
+curl -s --header "PRIVATE-TOKEN: $TOKEN" -X POST "$API/projects" \
+  --data "name=$PROJECT&visibility=public&initialize_with_readme=false" >/dev/null || true
+NS_PATH=$(curl -s --header "PRIVATE-TOKEN: $TOKEN" "$API/projects?search=$PROJECT" \
+  | python3 -c 'import sys,json; d=json.load(sys.stdin); print(d[0]["path_with_namespace"]) if d else print("")')
+echo "    project: $NS_PATH"
+
+echo "==> pushing repo/ (YAML tests + .gitlab-ci.yml)…"
+PUSH_DIR=$(mktemp -d)
+cp -R repo/. "$PUSH_DIR/"
+(
+  cd "$PUSH_DIR"
+  git init -q -b main
+  git config user.email demo@thorotest.local
+  git config user.name "ThoroTest Demo"
+  git add -A && git commit -qm "demo: tests-as-code + gitlab-ci pipeline"
+  git remote add origin "http://root:$TOKEN@localhost:8929/$NS_PATH.git"
+  git push -qf origin main
+)
+rm -rf "$PUSH_DIR"
+echo "    pushed to $NS_PATH @ main"
+
+echo "==> creating an instance runner + registering it (docker executor)…"
+RUNNER_TOKEN=$(curl -s --header "PRIVATE-TOKEN: $TOKEN" -X POST "$API/user/runners" \
+  --data "runner_type=instance_type&description=thorotest-demo&run_untagged=true&locked=false" \
+  | python3 -c 'import sys,json; print(json.load(sys.stdin).get("token",""))')
+if [ -z "$RUNNER_TOKEN" ]; then echo "failed to create runner token"; exit 1; fi
+
+dc exec -T runner gitlab-runner register --non-interactive \
+  --url "$INTERNAL_URL" \
+  --token "$RUNNER_TOKEN" \
+  --executor docker \
+  --docker-image "python:3.12-slim" \
+  --docker-network-mode "$NETWORK" \
+  --docker-volumes /var/run/docker.sock:/var/run/docker.sock \
+  --clone-url "$INTERNAL_URL"
+echo "    runner registered."
+
+cat <<EOF
+
+────────────────────────────────────────────────────────────
+GitLab demo ready.
+
+  Web UI : $WEB   (login: root / $ROOT_PW)
+  Project: $WEB/$NS_PATH
+
+Configure the ThoroTest integration with:
+  provider  : gitlab
+  repo_url  : $WEB/$NS_PATH
+  api_base  : $API
+  branch    : main
+  path      : tests/
+  token     : $TOKEN
+────────────────────────────────────────────────────────────
+EOF

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thorotest",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "Source-available test management platform. Organize, run, and track tests across manual and automated suites — one timeline for both.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Follow-up to #10 (real GitLab integration). Adds a reproducible end-to-end demo
against a **real self-hosted GitLab**, plus small polish, and bumps the release.

## `demo/gitlab/`
- **docker-compose.yml** — GitLab CE + a docker-executor runner.
- **setup.sh** — waits for the API, mints a root PAT (`api` scope), creates the
  `thorotest-demo` project, pushes `repo/`, and registers the runner. Uses
  `--clone-url http://gitlab:8929` so job git-clones resolve over the compose
  network without any host `/etc/hosts` edits.
- **repo/** — YAML tests (`tests/`, for Sync) and a `.gitlab-ci.yml` with two
  jobs: a green **pytest** job and a red **playwright** job (one intentional
  failure). The pipeline goes red, yet ThoroTest imports the merged
  `test_report` as one run — **5 pass / 1 fail** — because the JUnit reports
  publish even on failure (`artifacts: when: always`).
- **README.md** — bring-up, config values, teardown.

## Polish
- **Seed**: the GitLab integration row is now a real `vcs_ci` provider (was a
  cosmetic `ci` row), matching the GitHub seed row now that GitLab is
  first-class.

## Release
- Bump `1.4.1 → 1.5.0` (GitLab integration minor). Tag `v1.5.0` after merge.

## Verification
- Ran the full flow locally against the CE instance: Sync pulled the YAML tests;
  Run CI triggered pipeline #7 (pytest ✓, playwright ✗ → pipeline red) and
  imported one run of 5 pass / 1 fail.
- Backend suite: 535 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)