### PR TITLE
Two-way Tests-as-Code sync + link CI runs to schede

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ cp .env.example .env
 make docker-up-sqlite
 ```
 
-Database is created automatically on first run. Seed data: 19 test cases across 12 folders, 11 runs, 6 pipelines, 9 defects.
+Database is created automatically on first run. Seed data: 19 test cases across 12 folders, 11 runs, 9 defects. Pipelines are not seeded — the page fills from real CI runs (Configure ▸ Integrations ▸ Run CI).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -281,8 +281,8 @@ supported:
   import its JUnit artifact. See **[docs/github-actions-ci.md](docs/github-actions-ci.md)**
   for workflow requirements, token setup, and API usage.
 - **GitLab CI** — create a pipeline, poll it, and import its `test_report`
-  (jobs just need `artifacts: reports: junit:`). A local, dockerised demo lives
-  in **[demo/gitlab/](demo/gitlab/)**.
+  (jobs just need `artifacts: reports: junit:`). See **[docs/gitlab-ci.md](docs/gitlab-ci.md)**;
+  a local, dockerised demo lives in **[demo/gitlab/](demo/gitlab/)**.
 
 Each dispatch also appears on the **Pipelines** page (running → pass/fail, with
 commit, branch, and duration) — not only as an imported Run.

--- a/README.md
+++ b/README.md
@@ -131,18 +131,25 @@ Docker deployments.
 
 ---
 
-## Tests as Code (GitHub sync)
+## Tests as Code (GitHub + GitLab sync)
 
-Keep automated tests defined as YAML in a Git repo and mirror them into ThoroTest, read-only (Git is the source of truth). The test-detail page then shows the real file path, synced commit, raw YAML, and a **View on GitHub** link that points to the exact file at the synced commit.
+Keep tests defined as YAML in a Git repo and mirror them into ThoroTest. Works with **GitHub** (`github.com`) and **GitLab** (`gitlab.com` or self-hosted). The test-detail page shows the real file path, synced commit, raw YAML, and a link to the exact file at that commit.
+
+Sync is **two-way**:
+
+- **Pull** (Git → ThoroTest): reads the YAML schede and creates/updates tests.
+- **Push** (ThoroTest → Git): the test-detail YAML card has a **Push to git** button that commits the test's current state back to its source file. A conflict guard returns **409** if the file changed on Git since the last sync — re-sync first so you don't overwrite a change made on Git.
 
 ### Setup
 
-1. **Settings → Integrations → Add → GitHub**
+1. **Settings → Integrations → Add → GitHub** (or **GitLab**)
 2. Fill in:
-   - **Repository URL** — `https://github.com/acme/web`
+   - **Repository URL** — `https://github.com/acme/web` or `https://gitlab.com/acme/web`
+   - **Provider** — `github` / `gitlab`. Inferred from the host for the public clouds; **required** for self-hosted GitLab (any other host).
+   - **API base** _(GitLab only, optional)_ — e.g. `http://gitlab.internal/api/v4`; derived from the repo URL when omitted.
    - **Branch** — e.g. `main`
    - **Path** — folder holding the YAML tests, e.g. `tests/`
-   - **Personal access token** — only needed for private repos (`contents: read` scope). Stored in the integration config; never returned to clients (the API reports only `token_set: true`).
+   - **Personal access token** — needed for private repos and for **Push to git** (GitHub `contents: write`, GitLab `api`). Stored in the integration config; never returned to clients (the API reports only `token_set: true`).
 3. Click **Sync** on the integration row. ThoroTest reads every `*.yml` / `*.yaml` under the path at the latest commit, then creates/updates the matching tests and caches the file contents + commit sha.
 
 Re-syncing is idempotent: tests are matched by their YAML `id` (or, when absent, by repo + file path), so a second sync updates in place instead of duplicating.
@@ -154,7 +161,6 @@ id: TC-2301                       # stable id, reused as the test's primary key 
 title: "Stripe card charge succeeds on test card"
 type: automated                   # automated | manual  (aliases: e2e/auto/unit → automated)
 runner: playwright
-status: pending                   # pass/passed → pass, etc.
 priority: high                    # low | med | high | critical  (aliases: P0–P3)
 owner: anna@example.com
 tags: [smoke, payment]
@@ -163,9 +169,12 @@ folder: Checkout/Payment          # "/"-separated folder hierarchy, auto-created
 
 Only `title` is required. Malformed files are skipped and reported in the sync result (`warnings`), not fatal.
 
-### Endpoint
+**Status is not a YAML field.** A test's status is owned by real CI run results, not a hand-written value, so sync never reads a `status:` from the file and push never writes one back. See **[CI status link](#linking-schede-to-ci-results)** below for how run results flow onto the scheda.
 
-`POST /api/integrations/{id}/sync` (admin/manager) → `{ created, updated, skipped, commit, files, warnings, last_sync }`. Sync is restricted to `github.com` repos.
+### Endpoints
+
+- `POST /api/integrations/{id}/sync` (admin/manager) → `{ created, updated, skipped, commit, files, warnings, last_sync }`. Routes to GitHub or GitLab by the integration's provider.
+- `POST /api/tests/{id}/push-to-git` (admin/manager) → `{ ok, committed, commit, path, branch }`. **409** when the file diverged on Git; **400** when the test has no Git source or no integration matches its repo.
 
 ---
 
@@ -262,12 +271,35 @@ stable id, matching falls back to `(title, folder)`.
 
 ---
 
-## GitHub Actions CI
+## CI: run pipelines and import results
 
-Trigger a project's GitHub Actions workflow from ThoroTest and import its JUnit
-results automatically when the run finishes (Configure ▸ Integrations ▸ **Run
-CI**). See **[docs/github-actions-ci.md](docs/github-actions-ci.md)** for the
-workflow requirements, token setup, and API usage.
+Trigger a project's pipeline from ThoroTest and import its results automatically
+when the run finishes (Configure ▸ Integrations ▸ **Run CI**). Both providers are
+supported:
+
+- **GitHub Actions** — dispatch a `workflow_dispatch` workflow, then download and
+  import its JUnit artifact. See **[docs/github-actions-ci.md](docs/github-actions-ci.md)**
+  for workflow requirements, token setup, and API usage.
+- **GitLab CI** — create a pipeline, poll it, and import its `test_report`
+  (jobs just need `artifacts: reports: junit:`). A local, dockerised demo lives
+  in **[demo/gitlab/](demo/gitlab/)**.
+
+Each dispatch also appears on the **Pipelines** page (running → pass/fail, with
+commit, branch, and duration) — not only as an imported Run.
+
+### Linking schede to CI results
+
+A CI run's results are attached to the **same** test row the YAML scheda created
+(no duplicate), and the scheda's status is advanced to the real run result. The
+link is a correlation id: put the scheda's `id` in the automated test's name (or
+class), e.g. a Playwright title `login with valid credentials [TC-GL-100]` or a
+trailing `..._TC_GL_100`. On import, ThoroTest extracts that `TC-…` token and
+matches it to the scheda. Tests without a token still import as their own
+automated tests, so tagging is opt-in.
+
+So the full loop is: **Sync** creates schede (status `pending`) → **Run CI** runs
+the real pipeline → results link back and flip the schede to `pass`/`fail`. Status
+lives in one place (the run), never in the YAML.
 
 ---
 
@@ -440,12 +472,17 @@ WebSocket:
 
 ## Tests
 
-### Backend unit tests (492 tests)
+### Backend unit tests (576 tests)
 
 ```bash
 source venv/bin/activate
 python -m pytest backend/tests/ -v
 ```
+
+One live integration test (`test_gitlab_e2e_integration.py`) drives the real
+sync ↔ CI ↔ push loop against a running GitLab CE. It **skips** unless a GitLab is
+reachable and `GITLAB_E2E_TOKEN` is set (mint one via `demo/gitlab/setup.sh`), so
+the default run is unaffected.
 
 ```
 backend/tests/

--- a/backend/git_push.py
+++ b/backend/git_push.py
@@ -1,0 +1,94 @@
+"""Reverse "Tests as Code" sync — write ThoroTest edits back to git.
+
+The pull side (:mod:`backend.github_sync` / :mod:`backend.gitlab_sync`) reads
+YAML test files into Test rows. This module renders a Test row back to YAML and
+the provider modules commit it to the source file, so an edit made in the
+ThoroTest UI can be pushed to the repo it was synced from.
+
+Shared, provider-agnostic pieces live here:
+
+- :func:`render_test_yaml` — Test row → YAML document (folder path rebuilt from
+  the folder tree),
+- :class:`PushConflict` — raised when the file on git diverged from what we last
+  synced (``source_body``); the caller maps it to HTTP 409 so the user re-syncs
+  instead of clobbering a change made on git,
+- :func:`find_vcs_integration` — locate the integration a test was synced from
+  (its token + branch live in the integration config).
+
+The actual read-current-file / commit calls are provider-specific and live in
+each provider module's ``push_test``.
+"""
+from . import models
+from .importers import serialize_yaml_test
+
+
+class PushConflict(Exception):
+    """The file on git changed since the last sync — refuse to overwrite."""
+
+
+def _folder_path(db, folder_id: str | None) -> str:
+    """Rebuild a folder's "A/B/C" path from the folder tree (inverse of the
+    sync's ``_get_or_create_folder``)."""
+    parts: list[str] = []
+    seen: set[str] = set()
+    fid = folder_id
+    while fid and fid not in seen:
+        seen.add(fid)
+        folder = db.query(models.Folder).filter(models.Folder.id == fid).first()
+        if not folder:
+            break
+        parts.append(folder.name)
+        fid = folder.parent_id
+    return "/".join(reversed(parts))
+
+
+def render_test_yaml(db, test) -> str:
+    """Serialize a Test row to a "test as code" YAML document."""
+    fields = {
+        "id": test.id,
+        "title": test.title,
+        "type": test.type,
+        "runner": test.runner,
+        # status omitted on purpose — owned by CI run results, not the file.
+        "priority": test.priority,
+        "owner": test.owner,
+        "tags": test.tags or [],
+        "folder": _folder_path(db, test.folder_id),
+    }
+    return serialize_yaml_test(fields)
+
+
+def _norm(text: str | None) -> str:
+    """Compare file bodies ignoring trailing-whitespace / newline noise."""
+    return (text or "").strip()
+
+
+def check_conflict(current_remote: str | None, last_synced: str | None) -> None:
+    """Raise :class:`PushConflict` if the remote file diverged from last sync.
+
+    ``current_remote is None`` means the file doesn't exist on git yet (a new
+    test being pushed for the first time) — no conflict.
+    """
+    if current_remote is None:
+        return
+    if _norm(current_remote) != _norm(last_synced):
+        raise PushConflict(
+            "the file changed on git since the last sync — re-sync before "
+            "pushing so your edit doesn't overwrite the change on git"
+        )
+
+
+def find_vcs_integration(db, test):
+    """Find the VCS integration a test was synced from, matched by repo_url.
+
+    Returns the Integration or None. Jira integrations are ignored.
+    """
+    if not test.repo_url:
+        return None
+    for intg in db.query(models.Integration).all():
+        if intg.type == "jira":
+            continue
+        cfg = intg.config or {}
+        if (cfg.get("repo_url") or "").rstrip("/") == test.repo_url.rstrip("/"):
+            return intg
+    return None

--- a/backend/github_actions.py
+++ b/backend/github_actions.py
@@ -125,7 +125,7 @@ def collect_run_results(db, client, owner: str, repo: str, run_id: int,
     result = parse_junit_xml(junit)
     if run_name and result.runs:
         result.runs[0].name = run_name
-    return persist_import_result(db, result, PROVIDER, conflict="skip")
+    return persist_import_result(db, result, PROVIDER, conflict="skip", sync_status=True)
 
 
 def ci_config(integration) -> dict:

--- a/backend/github_sync.py
+++ b/backend/github_sync.py
@@ -8,6 +8,7 @@ integration config (only needed for private repos).
 The HTTP layer (GitHubClient) is kept separate from the DB upsert
 (sync_repo) so tests can inject a fake fetcher without network access.
 """
+import base64
 import re
 import uuid
 from datetime import datetime, timezone
@@ -16,6 +17,7 @@ import httpx
 
 from . import models
 from .importers import parse_yaml_test
+from .importers.junit_xml import extract_case_id
 
 API_ROOT = "https://api.github.com"
 _YAML_EXT = (".yml", ".yaml")
@@ -88,6 +90,45 @@ class GitHubClient:
         )
         return r.text
 
+    def get_file_meta(self, owner: str, repo: str, path: str, ref: str):
+        """(raw_text, blob_sha) for a file, or (None, None) if it doesn't exist.
+
+        The blob sha is required by the contents API to update an existing file.
+        """
+        try:
+            r = self._client.get(f"/repos/{owner}/{repo}/contents/{path}", params={"ref": ref})
+        except httpx.HTTPError as e:
+            raise RuntimeError(f"github request failed: {e}")
+        if r.status_code == 404:
+            return None, None
+        if r.status_code in (401, 403):
+            raise RuntimeError(f"github auth/rate-limit error ({r.status_code}): {r.text[:200]}")
+        if r.status_code >= 400:
+            raise RuntimeError(f"github error {r.status_code}: {r.text[:200]}")
+        j = r.json()
+        content = base64.b64decode(j.get("content", "")).decode("utf-8", errors="replace")
+        return content, j["sha"]
+
+    def put_file(self, owner: str, repo: str, path: str, content: str,
+                 message: str, branch: str, sha: str | None = None) -> str:
+        """Create or update a file; returns the new commit sha."""
+        body = {
+            "message": message,
+            "content": base64.b64encode(content.encode("utf-8")).decode("ascii"),
+            "branch": branch,
+        }
+        if sha:
+            body["sha"] = sha
+        try:
+            r = self._client.put(f"/repos/{owner}/{repo}/contents/{path}", json=body)
+        except httpx.HTTPError as e:
+            raise RuntimeError(f"github request failed: {e}")
+        if r.status_code in (401, 403):
+            raise RuntimeError(f"github auth error ({r.status_code}): {r.text[:200]}")
+        if r.status_code >= 400:
+            raise RuntimeError(f"github error {r.status_code}: {r.text[:200]}")
+        return r.json()["commit"]["sha"]
+
 
 def _get_or_create_folder(db, path: str, cache: dict) -> str | None:
     """Resolve a "A/B/C" folder path to a folder id, creating missing levels."""
@@ -130,11 +171,19 @@ def _fetch_files(repo_url: str, branch: str, path: str, token: str | None):
 
 
 def sync_repo(db, repo_url: str, branch: str, path: str, token: str | None = None,
-              fetcher=None) -> dict:
+              fetcher=None, link_provider: str | None = None) -> dict:
     """Read YAML tests from a repo and upsert them. Returns stats dict.
 
     `fetcher(repo_url, branch, path, token) -> (sha, [(file_path, content), ...])`
     is injectable for tests; defaults to the live GitHub client.
+
+    `link_provider` is the CI provider string ("github-actions" / "gitlab-ci")
+    this repo's pipeline imports under. When set, a scheda with an id is tagged
+    with that external identity so a later CI import links its run results to
+    this same test row (see :mod:`backend.importers.persist`) instead of
+    creating a duplicate. `status` is deliberately NOT taken from the YAML —
+    a test's status is owned by real run results, so a hand-written
+    `status:` in the file can't lie about it here.
     """
     fetch = fetcher or _fetch_files
     sha, files = fetch(repo_url, branch, path, token)
@@ -167,7 +216,7 @@ def sync_repo(db, repo_url: str, branch: str, path: str, token: str | None = Non
         target = existing or models.Test(id=data["id"] or f"TC-{uuid.uuid4().hex[:6].upper()}")
         target.title = data["title"]
         target.type = data["type"]
-        target.status = data["status"]
+        # NOTE: status intentionally not set from YAML — owned by CI run results.
         target.priority = data["priority"]
         target.owner = data["owner"] or (target.owner or "")
         target.tags = data["tags"]
@@ -180,6 +229,11 @@ def sync_repo(db, repo_url: str, branch: str, path: str, token: str | None = Non
         target.source_ref = sha
         target.source_body = content
         target.source_synced_at = now
+        # Tag with the CI external identity so a later pipeline import attaches
+        # its run results to this scheda instead of creating a duplicate.
+        if link_provider and data["id"]:
+            target.external_provider = link_provider
+            target.external_key = extract_case_id(data["id"]) or data["id"]
 
         if existing:
             stats["updated"] += 1
@@ -202,9 +256,35 @@ def sync_integration(db, integration) -> dict:
     path = cfg.get("path") or ""
     token = cfg.get("token") or None
 
-    stats = sync_repo(db, repo_url, branch, path, token)
+    stats = sync_repo(db, repo_url, branch, path, token, link_provider="github-actions")
 
     integration.last_sync = datetime.now(timezone.utc).isoformat()
     integration.status = "active"
     db.commit()
     return stats
+
+
+def push_test(db, integration, test, message: str | None = None) -> dict:
+    """Write a Test row back to its GitHub source file. Raises PushConflict when
+    the file diverged on git since the last sync."""
+    from .git_push import render_test_yaml, check_conflict
+
+    cfg = integration.config or {}
+    branch = cfg.get("branch") or "main"
+    token = cfg.get("token") or None
+    owner, repo = parse_repo_url(test.repo_url)
+    path = test.source_path
+    content = render_test_yaml(db, test)
+    msg = message or f"chore(tests): update {path} from ThoroTest"
+
+    with GitHubClient(token) as gh:
+        current, sha = gh.get_file_meta(owner, repo, path, branch)
+        check_conflict(current, test.source_body)
+        commit = gh.put_file(owner, repo, path, content, msg, branch, sha)
+
+    now = datetime.now(timezone.utc).isoformat()
+    test.source_ref = commit
+    test.source_body = content
+    test.source_synced_at = now
+    db.commit()
+    return {"committed": True, "commit": commit, "path": path, "branch": branch}

--- a/backend/gitlab_actions.py
+++ b/backend/gitlab_actions.py
@@ -11,7 +11,7 @@ import httpx
 
 from .gitlab_sync import GitLabClient, parse_gitlab_repo
 from .importers.base import ImportResult, TestData, RunData, CaseResult
-from .importers.junit_xml import _folder_for
+from .importers.junit_xml import _folder_for, extract_case_id
 from .importers.persist import persist_import_result
 
 PROVIDER = "gitlab-ci"
@@ -62,9 +62,10 @@ def parse_test_report(report: dict, run_name: str) -> ImportResult:
             classname = tc.get("classname") or ""
             status = _STATUS_MAP.get(tc.get("status"), "pending")
             folder = _folder_for(suite_name, classname)
+            case_id = extract_case_id(title, classname)
             tests.append(TestData(title=title, folder_path=folder,
-                                  type="automated", status=status))
-            cases.append(CaseResult(test_title=title, status=status))
+                                  type="automated", status=status, source_id=case_id))
+            cases.append(CaseResult(test_title=title, status=status, source_test_id=case_id))
     runs = [RunData(name=run_name, status="done", cases=cases)]
     return ImportResult(tests=tests, runs=runs, format_detected="gitlab_test_report")
 
@@ -75,7 +76,7 @@ def collect_pipeline_results(db, client, project: str, pipeline_id: int,
     report = client.get_test_report(project, pipeline_id)
     name = run_name or f"GitLab pipeline #{pipeline_id}"
     result = parse_test_report(report, name)
-    return persist_import_result(db, result, PROVIDER, conflict="skip")
+    return persist_import_result(db, result, PROVIDER, conflict="skip", sync_status=True)
 
 
 def ci_config(integration) -> dict:

--- a/backend/gitlab_sync.py
+++ b/backend/gitlab_sync.py
@@ -116,6 +116,35 @@ class GitLabClient:
         )
         return r.text
 
+    def get_file_opt(self, project: str, path: str, ref: str) -> str | None:
+        """Raw file content, or None if the file doesn't exist at ref."""
+        url = f"/projects/{self._enc(project)}/repository/files/{quote(path, safe='')}/raw"
+        try:
+            r = self._client.get(url, params={"ref": ref})
+        except httpx.HTTPError as e:
+            raise RuntimeError(f"gitlab request failed: {e}")
+        if r.status_code == 404:
+            return None
+        if r.status_code in (401, 403):
+            raise RuntimeError(f"gitlab auth error ({r.status_code}): {r.text[:200]}")
+        if r.status_code >= 400:
+            raise RuntimeError(f"gitlab error {r.status_code}: {r.text[:200]}")
+        return r.text
+
+    def write_file(self, project: str, path: str, content: str, branch: str,
+                   message: str, update: bool) -> None:
+        """Create (POST) or update (PUT) a file in a single commit."""
+        url = f"/projects/{self._enc(project)}/repository/files/{quote(path, safe='')}"
+        body = {"branch": branch, "content": content, "commit_message": message}
+        try:
+            r = self._client.request("PUT" if update else "POST", url, json=body)
+        except httpx.HTTPError as e:
+            raise RuntimeError(f"gitlab request failed: {e}")
+        if r.status_code in (401, 403):
+            raise RuntimeError(f"gitlab auth error ({r.status_code}): {r.text[:200]}")
+        if r.status_code >= 400:
+            raise RuntimeError(f"gitlab error {r.status_code}: {r.text[:200]}")
+
 
 def _fetch_files_factory(api_base: str, token: str | None):
     """Build a fetcher matching sync_repo's ``fetcher(repo_url, branch, path, token)``
@@ -142,9 +171,37 @@ def sync_integration(db, integration) -> dict:
     api_base, _ = parse_gitlab_repo(repo_url, cfg.get("api_base"))
 
     stats = sync_repo(db, repo_url, branch, path, token,
-                      fetcher=_fetch_files_factory(api_base, token))
+                      fetcher=_fetch_files_factory(api_base, token),
+                      link_provider="gitlab-ci")
 
     integration.last_sync = datetime.now(timezone.utc).isoformat()
     integration.status = "active"
     db.commit()
     return stats
+
+
+def push_test(db, integration, test, message: str | None = None) -> dict:
+    """Write a Test row back to its GitLab source file. Raises PushConflict when
+    the file diverged on git since the last sync."""
+    from .git_push import render_test_yaml, check_conflict
+
+    cfg = integration.config or {}
+    branch = cfg.get("branch") or "main"
+    token = cfg.get("token") or None
+    api_base, project = parse_gitlab_repo(test.repo_url, cfg.get("api_base"))
+    path = test.source_path
+    content = render_test_yaml(db, test)
+    msg = message or f"chore(tests): update {path} from ThoroTest"
+
+    with GitLabClient(api_base, token) as gl:
+        current = gl.get_file_opt(project, path, branch)
+        check_conflict(current, test.source_body)
+        gl.write_file(project, path, content, branch, msg, update=current is not None)
+        commit = gl.latest_commit(project, branch)
+
+    now = datetime.now(timezone.utc).isoformat()
+    test.source_ref = commit
+    test.source_body = content
+    test.source_synced_at = now
+    db.commit()
+    return {"committed": True, "commit": commit, "path": path, "branch": branch}

--- a/backend/importers/__init__.py
+++ b/backend/importers/__init__.py
@@ -5,7 +5,7 @@ from .testrail_xml import parse_testrail_xml
 from .testlink_xml import parse_testlink_xml
 from .junit_xml import parse_junit_xml
 from .json_importer import parse_json
-from .yaml_importer import parse_yaml_test
+from .yaml_importer import parse_yaml_test, serialize_yaml_test
 from .zephyr_json import parse_zephyr
 from .xray_json import parse_xray
 from .qtest_json import parse_qtest
@@ -14,5 +14,5 @@ __all__ = [
     "ImportResult", "TestData", "RunData", "DefectData",
     "detect_format", "parse_csv", "parse_xlsx", "parse_testrail_xml", "parse_testlink_xml",
     "parse_junit_xml", "parse_json",
-    "parse_yaml_test", "parse_zephyr", "parse_xray", "parse_qtest",
+    "parse_yaml_test", "serialize_yaml_test", "parse_zephyr", "parse_xray", "parse_qtest",
 ]

--- a/backend/importers/junit_xml.py
+++ b/backend/importers/junit_xml.py
@@ -1,6 +1,33 @@
+import re
 import xml.etree.ElementTree as ET
 from datetime import datetime
 from .base import ImportResult, TestData, RunData, CaseResult
+
+# A test-case id embedded in an automated test's name/classname, so a CI run can
+# be linked back to the "test as code" YAML scheda it exercises. Matches
+# "TC-GL-100", "TC_GL_100", "[TC-GL-100]" → normalized to "TC-GL-100".
+#
+# A separator after "TC" is REQUIRED (so "TCP", "TContext" don't match) and the
+# "TC" must not sit inside a longer alphanumeric run (so "BTC-100" doesn't
+# match). The lookbehind excludes only alnum — an underscore before "TC"
+# (e.g. "login_TC_GL_100") is a valid separator, not part of a word.
+_CASE_ID_RE = re.compile(r"(?<![A-Za-z0-9])TC[-_ ]([A-Za-z0-9]+(?:[-_][A-Za-z0-9]+)*)")
+
+
+def extract_case_id(*parts: str) -> str:
+    """Pull a normalized "TC-…" case id out of a test name/classname, or "".
+
+    The first ``parts`` value containing a token wins. Used to correlate CI
+    results (B) with YAML-synced test definitions (A); when no token is present
+    the caller falls back to title/folder matching, so this is opt-in per test.
+    """
+    for part in parts:
+        m = _CASE_ID_RE.search(part or "")
+        if m:
+            tail = m.group(1).replace("_", "-")
+            return f"TC-{tail}".upper()
+    return ""
+
 
 _STATUS_MAP = {
     "passed": "pass",
@@ -71,6 +98,7 @@ def parse_junit_xml(content: bytes) -> ImportResult:
 
             folder_path = _folder_for(suite_name, classname)
             status = _junit_status(case_el)
+            case_id = extract_case_id(title, classname)
 
             if title not in tests_map:
                 tests_map[title] = TestData(
@@ -78,9 +106,10 @@ def parse_junit_xml(content: bytes) -> ImportResult:
                     folder_path=folder_path,
                     type="automated",
                     status="pending",
+                    source_id=case_id,
                 )
 
-            cases.append(CaseResult(test_title=title, status=status))
+            cases.append(CaseResult(test_title=title, status=status, source_test_id=case_id))
 
     total = len(cases)
     passed = sum(1 for c in cases if c.status == "pass")

--- a/backend/importers/persist.py
+++ b/backend/importers/persist.py
@@ -11,9 +11,16 @@ from .. import models
 from .base import ImportResult
 
 
-def persist_import_result(db, result: ImportResult, provider: str, conflict: str = "skip") -> dict:
+def persist_import_result(db, result: ImportResult, provider: str, conflict: str = "skip",
+                          sync_status: bool = False) -> dict:
     """Write tests/runs/defects from `result`. `conflict` = skip | overwrite |
-    rename. Returns a stats dict. Commits the session."""
+    rename. Returns a stats dict. Commits the session.
+
+    When `sync_status` is True, each test a run case links to has its own
+    `status` advanced to that case's result — so a real CI run updates the
+    test's current status (last case wins). Off by default: file imports of a
+    plain results file shouldn't silently rewrite test statuses; the CI
+    collectors opt in so a pipeline result is the source of truth for status."""
     now = datetime.now(timezone.utc).isoformat()
     stats = {"folders": 0, "tests": 0, "runs": 0, "defects": 0, "skipped": 0}
 
@@ -180,6 +187,11 @@ def persist_import_result(db, result: ImportResult, provider: str, conflict: str
             if not test_id:
                 continue
             db.add(models.RunCase(run_id=rid, test_id=test_id, status=case.status))
+            if sync_status:
+                linked = db.query(models.Test).filter(models.Test.id == test_id).first()
+                if linked is not None:
+                    linked.status = case.status
+                    linked.last_run_at = now
 
         stats["runs"] += 1
 

--- a/backend/importers/yaml_importer.py
+++ b/backend/importers/yaml_importer.py
@@ -84,3 +84,35 @@ def parse_yaml_test(content: bytes | str) -> dict:
         "folder_path": folder,
         "auto": type_ == "automated",
     }
+
+
+# Key order for serialized files — matches the documented file shape above so
+# a synced-then-pushed file reads naturally and diffs stay small. `status` is
+# deliberately omitted: a test's status is owned by real CI run results, not a
+# hand-written field, so we never write it back into the source file.
+_DUMP_ORDER = ("id", "title", "type", "runner", "priority", "owner",
+               "tags", "folder")
+
+
+def serialize_yaml_test(fields: dict) -> str:
+    """Render a Test's fields back to a "test as code" YAML document.
+
+    Inverse of :func:`parse_yaml_test` (round-trips through the normalized
+    values). ``fields`` accepts the Test model's attribute names plus
+    ``folder`` (the "/"-joined folder path). Empty/blank values are omitted so
+    the file stays terse; ``title`` is always emitted.
+    """
+    out: dict = {}
+    for key in _DUMP_ORDER:
+        val = fields.get(key)
+        if key == "tags":
+            if val:
+                out["tags"] = [str(t) for t in val]
+            continue
+        if val in (None, "", []):
+            continue
+        out[key] = str(val)
+    if "title" not in out:
+        out["title"] = str(fields.get("title") or "").strip()
+    return yaml.safe_dump(out, sort_keys=False, allow_unicode=True,
+                          default_flow_style=False)

--- a/backend/models.py
+++ b/backend/models.py
@@ -145,6 +145,7 @@ class Pipeline(Base):
     author = Column(String(255), nullable=True)
     branch = Column(String(255), nullable=True)
     when = Column(String(64), nullable=True)
+    url = Column(String(512), nullable=True)   # link to the run on GitHub/GitLab
 
 
 class TestPlan(Base):

--- a/backend/routers/ci.py
+++ b/backend/routers/ci.py
@@ -37,6 +37,42 @@ RUN_TIMEOUT = 1800      # seconds to wait for the run to complete
 _JOBS: dict[str, dict] = {}
 
 
+def _fmt_duration(seconds) -> str | None:
+    """Seconds → "4m 12s" / "38s" for the pipelines table, or None."""
+    if not seconds:
+        return None
+    m, s = divmod(int(seconds), 60)
+    return f"{m}m {s:02d}s" if m else f"{s}s"
+
+
+def _gh_run_seconds(detail: dict) -> float | None:
+    """Elapsed seconds of a GitHub run from its timestamps, or None."""
+    start = detail.get("run_started_at") or detail.get("created_at")
+    end = detail.get("updated_at")
+    if not (start and end):
+        return None
+    try:
+        s = datetime.fromisoformat(start.replace("Z", "+00:00"))
+        e = datetime.fromisoformat(end.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    secs = (e - s).total_seconds()
+    return secs if secs > 0 else None
+
+
+def _upsert_pipeline(db, pid: str, **fields) -> None:
+    """Create/update the Pipeline row the pipelines page shows, so a live
+    "Run CI" dispatch appears there (running → pass/fail) — not just as a Run."""
+    p = db.query(models.Pipeline).filter(models.Pipeline.id == pid).first()
+    if p is None:
+        p = models.Pipeline(id=pid)
+        db.add(p)
+    for k, v in fields.items():
+        if v is not None:
+            setattr(p, k, v)
+    db.commit()
+
+
 class CIRunRequest(BaseModel):
     workflow: Optional[str] = None    # override integration config
     ref: Optional[str] = None
@@ -83,6 +119,23 @@ def _orchestrate(job_id: str, cfg: dict, since: datetime, run_name: Optional[str
             job["gh_run_url"] = run.get("html_url")
             job["status"] = "running"
 
+            # Record the live run on the pipelines page (running → pass/fail).
+            pipeline_row_id = f"gh-run-{run['id']}"
+            job["pipeline_row_id"] = pipeline_row_id
+            db0 = SessionLocal()
+            try:
+                _upsert_pipeline(
+                    db0, pipeline_row_id,
+                    name=run_name or run.get("name") or cfg["workflow"],
+                    platform="github", status="running",
+                    commit=(run.get("head_sha") or "")[:7] or None,
+                    branch=run.get("head_branch") or cfg["ref"],
+                    author=(run.get("actor") or {}).get("login"),
+                    when="just now",
+                )
+            finally:
+                db0.close()
+
             # 2. poll until completed
             deadline = time.time() + RUN_TIMEOUT
             while time.time() < deadline:
@@ -101,6 +154,12 @@ def _orchestrate(job_id: str, cfg: dict, since: datetime, run_name: Optional[str
                 stats = collect_run_results(
                     db, client, cfg["owner"], cfg["repo"], run["id"],
                     cfg["artifact"], run_name,
+                )
+                concl = job.get("conclusion")
+                _upsert_pipeline(
+                    db, pipeline_row_id,
+                    status="pass" if concl == "success" else "fail",
+                    duration=_fmt_duration(_gh_run_seconds(detail)),
                 )
             finally:
                 db.close()
@@ -140,6 +199,14 @@ def _orchestrate_gitlab(job_id: str, cfg: dict, run_name: Optional[str]) -> None
             db = SessionLocal()
             try:
                 stats = collect_pipeline_results(db, client, cfg["project"], pipeline_id, run_name)
+                pid = job.get("pipeline_row_id")
+                if pid:
+                    concl = job.get("conclusion")
+                    _upsert_pipeline(
+                        db, pid,
+                        status="pass" if concl == "success" else "fail",
+                        duration=_fmt_duration(detail.get("duration")),
+                    )
             finally:
                 db.close()
 
@@ -175,6 +242,14 @@ async def ci_run(intg_id: str, payload: CIRunRequest, db: Session = Depends(get_
             raise HTTPException(status_code=502, detail=f"Dispatch failed: {e}")
 
         job_id = uuid.uuid4().hex[:12]
+        pipeline_row_id = f"gl-pipeline-{pipeline.get('id')}"
+        _upsert_pipeline(
+            db, pipeline_row_id,
+            name=payload.run_name or f"GitLab pipeline #{pipeline.get('id')}",
+            platform="gitlab", status="running",
+            commit=(pipeline.get("sha") or "")[:7] or None,
+            branch=pipeline.get("ref") or cfg["ref"], when="just now",
+        )
         _JOBS[job_id] = {
             "id": job_id,
             "integration_id": intg_id,
@@ -184,6 +259,7 @@ async def ci_run(intg_id: str, payload: CIRunRequest, db: Session = Depends(get_
             "started_at": since.isoformat(),
             "gl_pipeline_id": pipeline.get("id"),
             "gh_run_url": pipeline.get("web_url"),
+            "pipeline_row_id": pipeline_row_id,
         }
         asyncio.create_task(asyncio.to_thread(_orchestrate_gitlab, job_id, cfg, payload.run_name))
         return {"job_id": job_id, "status": "dispatched", "workflow": "pipeline", "ref": cfg["ref"]}

--- a/backend/routers/ci.py
+++ b/backend/routers/ci.py
@@ -132,6 +132,7 @@ def _orchestrate(job_id: str, cfg: dict, since: datetime, run_name: Optional[str
                     branch=run.get("head_branch") or cfg["ref"],
                     author=(run.get("actor") or {}).get("login"),
                     when="just now",
+                    url=run.get("html_url"),
                 )
             finally:
                 db0.close()
@@ -249,6 +250,7 @@ async def ci_run(intg_id: str, payload: CIRunRequest, db: Session = Depends(get_
             platform="gitlab", status="running",
             commit=(pipeline.get("sha") or "")[:7] or None,
             branch=pipeline.get("ref") or cfg["ref"], when="just now",
+            url=pipeline.get("web_url"),
         )
         _JOBS[job_id] = {
             "id": job_id,

--- a/backend/routers/pipelines.py
+++ b/backend/routers/pipelines.py
@@ -59,3 +59,13 @@ def upsert_pipeline(payload: PipelineCreate, db: Session = Depends(get_db), _: m
     db.commit()
     db.refresh(pipe)
     return pipe
+
+
+@router.delete("/pipelines/{pipeline_id}", status_code=204)
+def delete_pipeline(pipeline_id: str, db: Session = Depends(get_db), _: models.User = WRITE_ROLES):
+    """Remove a pipeline run from the list (the run on the CI provider is untouched)."""
+    pipe = db.query(models.Pipeline).filter(models.Pipeline.id == pipeline_id).first()
+    if not pipe:
+        raise HTTPException(status_code=404, detail="Pipeline not found")
+    db.delete(pipe)
+    db.commit()

--- a/backend/routers/pipelines.py
+++ b/backend/routers/pipelines.py
@@ -35,7 +35,7 @@ def upsert_pipeline(payload: PipelineCreate, db: Session = Depends(get_db), _: m
         existing = db.query(models.Pipeline).filter(models.Pipeline.id == payload.id).first()
 
     if existing:
-        for field in ("name", "platform", "status", "duration", "commit", "author", "branch", "when"):
+        for field in ("name", "platform", "status", "duration", "commit", "author", "branch", "when", "url"):
             value = getattr(payload, field)
             if value is not None:
                 setattr(existing, field, value)
@@ -53,6 +53,7 @@ def upsert_pipeline(payload: PipelineCreate, db: Session = Depends(get_db), _: m
         author=payload.author,
         branch=payload.branch,
         when=payload.when or "just now",
+        url=payload.url,
     )
     db.add(pipe)
     db.commit()

--- a/backend/routers/tests.py
+++ b/backend/routers/tests.py
@@ -13,11 +13,16 @@ from ..auth_utils import require_role, get_current_user
 from ..notifications import _notify_comment_event
 from ..audit_utils import log_event, EVT_TEST_CREATED, EVT_TEST_UPDATED, EVT_TEST_DELETED
 from ..activity_utils import log_activity, actor_name
+from ..vcs import detect_provider
+from ..git_push import find_vcs_integration, PushConflict
+from ..github_sync import push_test as github_push_test
+from ..gitlab_sync import push_test as gitlab_push_test
 from ._pagination import paginate, MAX_LIMIT
 
 router = APIRouter(tags=["tests"])
 
 WRITE_ROLES = require_role("admin", "manager", "tester")
+GIT_PUSH_ROLES = require_role("admin", "manager")
 ADMIN_ONLY = require_role("admin")
 
 
@@ -161,6 +166,43 @@ def update_test(test_id: str, payload: TestUpdate, db: Session = Depends(get_db)
         target_id=str(t.id),
     )
     return t
+
+
+@router.post("/tests/{test_id}/push-to-git")
+def push_test_to_git(test_id: str, db: Session = Depends(get_db),
+                     current_user: models.User = GIT_PUSH_ROLES):
+    """Write a git-linked test's current state back to its source file (reverse
+    of "Tests as Code" sync). 409 if the file changed on git since last sync."""
+    t = db.query(models.Test).filter(models.Test.id == test_id).first()
+    if not t:
+        raise HTTPException(status_code=404, detail="Test not found")
+    if not t.source_path or not t.repo_url:
+        raise HTTPException(status_code=400, detail="Test is not linked to a git source")
+    intg = find_vcs_integration(db, t)
+    if not intg:
+        raise HTTPException(status_code=400,
+                            detail="No VCS integration matches this test's repo — configure one first")
+    try:
+        if detect_provider(intg.config or {}) == "gitlab":
+            stats = gitlab_push_test(db, intg, t)
+        else:
+            stats = github_push_test(db, intg, t)
+    except PushConflict as e:
+        raise HTTPException(status_code=409, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except RuntimeError as e:
+        raise HTTPException(status_code=502, detail=str(e))
+    log_activity(db, actor_name(current_user), "pushed", test_id, f"to git — {t.title}")
+    log_event(
+        EVT_TEST_UPDATED,
+        actor_id=current_user.id,
+        actor_email=current_user.email,
+        description=f"{current_user.email} pushed test '{t.title}' to git ({stats['path']} @ {stats['commit'][:7]})",
+        target_type="test",
+        target_id=str(t.id),
+    )
+    return {"ok": True, **stats}
 
 
 @router.delete("/tests/{test_id}", status_code=204)

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -167,6 +167,7 @@ class PipelineOut(BaseModel):
     author: Optional[str] = None
     branch: Optional[str] = None
     when: Optional[str] = None
+    url: Optional[str] = None
 
     model_config = {"from_attributes": True}
 
@@ -181,6 +182,7 @@ class PipelineCreate(BaseModel):
     author: Optional[str] = None
     branch: Optional[str] = None
     when: Optional[str] = None
+    url: Optional[str] = None
 
 
 class ActivityOut(BaseModel):

--- a/backend/seed.py
+++ b/backend/seed.py
@@ -138,15 +138,8 @@ def seed_db():
         ]
         db.add_all(run_cases)
 
-        pipelines = [
-            models.Pipeline(id="wf-1", name="ci.yml — Pull Request checks", platform="github", status="pass", duration="4m 12s", commit="a3c9f1d", author="marco.r", branch="feature/coupon-stack", when="8m ago"),
-            models.Pipeline(id="wf-2", name="nightly.yml — Full regression", platform="github", status="fail", duration="23m 04s", commit="fe21088", author="ci-bot", branch="main", when="8h ago"),
-            models.Pipeline(id="wf-3", name="e2e.yml — Playwright suite", platform="github", status="pass", duration="11m 38s", commit="a3c9f1d", author="marco.r", branch="feature/coupon-stack", when="8m ago"),
-            models.Pipeline(id="wf-4", name="release.gitlab-ci.yml — Staging deploy", platform="gitlab", status="running", duration="2m 41s", commit="771ab02", author="luca.p", branch="release/4.2.0", when="3m ago"),
-            models.Pipeline(id="wf-5", name="Jenkinsfile — Load test", platform="jenkins", status="pass", duration="18m 22s", commit="fe21088", author="ci-bot", branch="main", when="1d ago"),
-            models.Pipeline(id="wf-6", name="cypress.yml — Component tests", platform="github", status="pass", duration="3m 02s", commit="a3c9f1d", author="marco.r", branch="feature/coupon-stack", when="8m ago"),
-        ]
-        db.add_all(pipelines)
+        # Pipelines are populated by real CI runs (Configure ▸ Integrations ▸
+        # Run CI), not seeded — the page shows only actual dispatches.
 
         activities = [
             models.Activity(who="Marco R.", what="marked", target="TC-2302", detail="as ⚠ blocked — needs 3DS test card", when="12m", created_at=_ago(minutes=12)),

--- a/backend/tests/test_ci_pipeline_row.py
+++ b/backend/tests/test_ci_pipeline_row.py
@@ -25,10 +25,12 @@ def test_upsert_pipeline_creates_then_updates(db):
     pid = "gl-pipeline-42"
     # dispatch: running row appears
     _upsert_pipeline(db, pid, name="GitLab pipeline #42", platform="gitlab",
-                     status="running", commit="abc1234", branch="main", when="just now")
+                     status="running", commit="abc1234", branch="main", when="just now",
+                     url="http://gl/42")
     p = db.query(models.Pipeline).filter_by(id=pid).first()
     assert p is not None and p.status == "running" and p.platform == "gitlab"
     assert p.commit == "abc1234" and p.duration is None
+    assert p.url == "http://gl/42"
 
     # completion: same id updated in place, no duplicate
     _upsert_pipeline(db, pid, status="fail", duration=_fmt_duration(252))
@@ -66,6 +68,7 @@ def test_ci_run_creates_running_pipeline_row(client, db, monkeypatch):
     assert p.status == "running" and p.platform == "gitlab"
     assert p.commit == "deadbee" and p.branch == "main"
     assert p.name == "My run"
+    assert p.url == "http://x/99"   # links to the run on GitLab
 
 
 def test_ci_run_unknown_integration_404(client, db):

--- a/backend/tests/test_ci_pipeline_row.py
+++ b/backend/tests/test_ci_pipeline_row.py
@@ -1,0 +1,41 @@
+"""CI "Run" → Pipeline row on the pipelines page (running → pass/fail)."""
+import pytest
+
+from backend import models
+from backend.routers.ci import _fmt_duration, _gh_run_seconds, _upsert_pipeline
+
+
+@pytest.mark.parametrize("secs,out", [
+    (252, "4m 12s"), (38, "38s"), (60, "1m 00s"), (0, None), (None, None),
+])
+def test_fmt_duration(secs, out):
+    assert _fmt_duration(secs) == out
+
+
+def test_gh_run_seconds():
+    d = {"run_started_at": "2026-07-09T10:00:00Z", "updated_at": "2026-07-09T10:04:12Z"}
+    assert _gh_run_seconds(d) == 252.0
+    assert _gh_run_seconds({"created_at": "2026-07-09T10:00:00Z",
+                            "updated_at": "2026-07-09T10:00:05Z"}) == 5.0
+    assert _gh_run_seconds({}) is None
+    assert _gh_run_seconds({"created_at": "x", "updated_at": "y"}) is None
+
+
+def test_upsert_pipeline_creates_then_updates(db):
+    pid = "gl-pipeline-42"
+    # dispatch: running row appears
+    _upsert_pipeline(db, pid, name="GitLab pipeline #42", platform="gitlab",
+                     status="running", commit="abc1234", branch="main", when="just now")
+    p = db.query(models.Pipeline).filter_by(id=pid).first()
+    assert p is not None and p.status == "running" and p.platform == "gitlab"
+    assert p.commit == "abc1234" and p.duration is None
+
+    # completion: same id updated in place, no duplicate
+    _upsert_pipeline(db, pid, status="fail", duration=_fmt_duration(252))
+    assert db.query(models.Pipeline).filter_by(id=pid).count() == 1
+    p = db.query(models.Pipeline).filter_by(id=pid).first()
+    assert p.status == "fail"
+    assert p.duration == "4m 12s"
+    # None fields don't clobber existing values
+    assert p.name == "GitLab pipeline #42"
+    assert p.commit == "abc1234"

--- a/backend/tests/test_ci_pipeline_row.py
+++ b/backend/tests/test_ci_pipeline_row.py
@@ -39,3 +39,56 @@ def test_upsert_pipeline_creates_then_updates(db):
     # None fields don't clobber existing values
     assert p.name == "GitLab pipeline #42"
     assert p.commit == "abc1234"
+
+
+# ── ci_run endpoint: dispatch + error paths ─────────────────────
+
+def _gl_integration(db, iid="int-gl"):
+    db.add(models.Integration(
+        id=iid, name="GitLab", type="vcs_ci", icon="gitlab",
+        config={"provider": "gitlab", "repo_url": "https://gitlab.com/acme/web",
+                "branch": "main", "token": "glpat-x"}))
+    db.commit()
+
+
+def test_ci_run_creates_running_pipeline_row(client, db, monkeypatch):
+    from backend.routers import ci as ci_router
+    monkeypatch.setattr(ci_router, "_do_dispatch_gitlab",
+                        lambda cfg: {"id": 99, "web_url": "http://x/99", "sha": "deadbeef123", "ref": "main"})
+    monkeypatch.setattr(ci_router, "_orchestrate_gitlab", lambda *a, **k: None)
+    _gl_integration(db)
+
+    r = client.post("/api/integrations/int-gl/ci/run", json={"run_name": "My run"})
+    assert r.status_code == 200, r.text
+    # a running row now shows on the pipelines page
+    p = db.query(models.Pipeline).filter_by(id="gl-pipeline-99").first()
+    assert p is not None
+    assert p.status == "running" and p.platform == "gitlab"
+    assert p.commit == "deadbee" and p.branch == "main"
+    assert p.name == "My run"
+
+
+def test_ci_run_unknown_integration_404(client, db):
+    r = client.post("/api/integrations/nope/ci/run", json={})
+    assert r.status_code == 404
+
+
+def test_ci_run_non_vcs_integration_400(client, db):
+    db.add(models.Integration(id="mystery", name="Mystery", type="vcs_ci", icon="plug",
+                              config={"repo_url": "https://example.com/a/b"}))
+    db.commit()
+    r = client.post("/api/integrations/mystery/ci/run", json={})
+    assert r.status_code == 400
+
+
+def test_ci_run_dispatch_failure_502(client, db, monkeypatch):
+    from backend.routers import ci as ci_router
+
+    def _boom(cfg):
+        raise RuntimeError("gitlab down")
+    monkeypatch.setattr(ci_router, "_do_dispatch_gitlab", _boom)
+    _gl_integration(db, "int-gl-boom")
+    r = client.post("/api/integrations/int-gl-boom/ci/run", json={})
+    assert r.status_code == 502
+    # no pipeline row left behind on dispatch failure
+    assert db.query(models.Pipeline).filter(models.Pipeline.id.like("gl-pipeline-%")).count() == 0

--- a/backend/tests/test_ci_pipeline_row.py
+++ b/backend/tests/test_ci_pipeline_row.py
@@ -84,6 +84,18 @@ def test_ci_run_non_vcs_integration_400(client, db):
     assert r.status_code == 400
 
 
+def test_delete_pipeline(client, db):
+    db.add(models.Pipeline(id="wf-del", name="ci.yml", platform="github", status="pass"))
+    db.commit()
+    r = client.delete("/api/pipelines/wf-del")
+    assert r.status_code == 204
+    assert db.query(models.Pipeline).filter_by(id="wf-del").first() is None
+
+
+def test_delete_pipeline_unknown_404(client, db):
+    assert client.delete("/api/pipelines/nope").status_code == 404
+
+
 def test_ci_run_dispatch_failure_502(client, db, monkeypatch):
     from backend.routers import ci as ci_router
 

--- a/backend/tests/test_git_push.py
+++ b/backend/tests/test_git_push.py
@@ -160,6 +160,36 @@ def test_github_push_test_conflict(db, monkeypatch):
 
 # ── gitlab push_test ────────────────────────────────────────────
 
+def test_github_push_test_creates_new_file(db, monkeypatch):
+    class _New(_FakeGH):
+        def get_file_meta(self, owner, repo, path, ref):
+            return None, None   # file doesn't exist yet → create, no conflict
+
+    monkeypatch.setattr(github_sync, "GitHubClient", _New)
+    t = _make_test(db, source_body=None)   # never synced content
+    intg = models.Integration(id="i-new", name="GH", type="vcs_ci", icon="github",
+                              config={"repo_url": t.repo_url, "branch": "main"})
+    stats = github_sync.push_test(db, intg, t)
+    assert stats["committed"] is True
+    assert _FakeGH.instance.written["sha"] is None   # create path: no blob sha
+
+
+# ── gitlab push_test ────────────────────────────────────────────
+
+def test_gitlab_push_test_creates_new_file(db, monkeypatch):
+    class _New(_FakeGL):
+        def get_file_opt(self, project, path, ref):
+            return None   # file absent → POST (create)
+
+    monkeypatch.setattr(gitlab_sync, "GitLabClient", _New)
+    t = _make_test(db, id="TC-GLN", repo_url="https://gitlab.com/acme/web", source_body=None)
+    intg = models.Integration(id="i-gln", name="GL", type="vcs_ci", icon="gitlab",
+                              config={"provider": "gitlab", "repo_url": t.repo_url, "branch": "main"})
+    stats = gitlab_sync.push_test(db, intg, t)
+    assert stats["commit"] == "glnewsha"
+    assert _FakeGL.instance.written["update"] is False   # create, not update
+
+
 def test_gitlab_push_test_commits_and_updates_row(db, monkeypatch):
     monkeypatch.setattr(gitlab_sync, "GitLabClient", _FakeGL)
     t = _make_test(db, id="TC-GL", repo_url="https://gitlab.com/acme/web",
@@ -212,6 +242,21 @@ def test_push_endpoint_no_matching_integration(client, db):
     _make_test(db, id="TC-NOINT", repo_url="https://github.com/nomatch/repo")
     r = client.post("/api/tests/TC-NOINT/push-to-git")
     assert r.status_code == 400
+
+
+def test_find_vcs_integration_skips_jira(db):
+    # A jira integration must never be treated as the test's VCS source, even if
+    # its config happens to carry a matching repo_url.
+    db.add(models.Integration(id="jira", name="Jira", type="jira", icon="jira",
+                              config={"repo_url": "https://github.com/acme/web"}))
+    db.commit()
+    t = _make_test(db, id="TC-J", repo_url="https://github.com/acme/web")
+    assert git_push.find_vcs_integration(db, t) is None
+    # add the real vcs integration → now found
+    db.add(models.Integration(id="gh", name="GH", type="vcs_ci", icon="github",
+                              config={"repo_url": "https://github.com/acme/web"}))
+    db.commit()
+    assert git_push.find_vcs_integration(db, t).id == "gh"
 
 
 # ── A↔B link: CI run results attach to the YAML scheda ──────────

--- a/backend/tests/test_git_push.py
+++ b/backend/tests/test_git_push.py
@@ -1,0 +1,307 @@
+"""Reverse "Tests as Code" sync — serializer + write-back (github + gitlab)."""
+import pytest
+
+from backend import models, github_sync, gitlab_sync, git_push, gitlab_actions
+from backend.importers import parse_yaml_test, serialize_yaml_test
+from backend.importers.base import ImportResult, TestData as TD, RunData, CaseResult
+from backend.importers.junit_xml import extract_case_id, parse_junit_xml
+from backend.importers.persist import persist_import_result
+
+
+# ── serializer round-trip ───────────────────────────────────────
+
+def test_serialize_yaml_test_round_trips():
+    fields = {
+        "id": "TC-2301", "title": "Stripe charge", "type": "automated",
+        "runner": "playwright", "status": "pass", "priority": "high",
+        "owner": "anna@example.com", "tags": ["smoke", "payment"],
+        "folder": "Checkout/Payment",
+    }
+    text = serialize_yaml_test(fields)
+    parsed = parse_yaml_test(text)
+    assert parsed["id"] == "TC-2301"
+    assert parsed["title"] == "Stripe charge"
+    assert parsed["type"] == "automated"
+    assert parsed["priority"] == "high"
+    assert parsed["runner"] == "playwright"
+    assert parsed["tags"] == ["smoke", "payment"]
+    assert parsed["folder_path"] == "Checkout/Payment"
+    # status is owned by CI run results, never written back into the file
+    assert "status:" not in text
+
+
+def test_serialize_yaml_test_omits_empty():
+    text = serialize_yaml_test({"title": "bare", "type": "manual",
+                                "runner": None, "owner": "", "tags": [], "folder": ""})
+    assert "runner" not in text
+    assert "owner" not in text
+    assert "tags" not in text
+    assert "folder" not in text
+    assert "title: bare" in text
+
+
+def test_serialize_yaml_test_key_order():
+    text = serialize_yaml_test({"id": "TC-1", "title": "T", "type": "manual"})
+    assert text.index("id:") < text.index("title:") < text.index("type:")
+
+
+# ── folder path rebuild ─────────────────────────────────────────
+
+def test_folder_path_rebuilds_hierarchy(db):
+    db.add(models.Folder(id="F-A", name="Checkout", parent_id=None))
+    db.add(models.Folder(id="F-B", name="Payment", parent_id="F-A"))
+    db.commit()
+    assert git_push._folder_path(db, "F-B") == "Checkout/Payment"
+    assert git_push._folder_path(db, None) == ""
+
+
+# ── conflict guard ──────────────────────────────────────────────
+
+def test_check_conflict():
+    git_push.check_conflict(None, "anything")           # new file: no conflict
+    git_push.check_conflict("same\n", "same")            # unchanged: ok (norm)
+    with pytest.raises(git_push.PushConflict):
+        git_push.check_conflict("changed on git", "what we synced")
+
+
+# ── fakes ───────────────────────────────────────────────────────
+
+def _make_test(db, **over):
+    defaults = dict(
+        id="TC-P1", title="pushable", type="automated", status="pass",
+        priority="high", runner="playwright", owner="qa@acme.com", tags=["smoke"],
+        repo_url="https://github.com/acme/web", source_path="tests/a.yml",
+        source_ref="oldsha", source_body='id: TC-P1\ntitle: "old"\n',
+        source_synced_at="2026-01-01T00:00:00+00:00",
+    )
+    defaults.update(over)
+    t = models.Test(**defaults)
+    db.add(t)
+    db.commit()
+    return t
+
+
+class _FakeGH:
+    instance = None
+
+    def __init__(self, *a, **k):
+        _FakeGH.instance = self
+        self.written = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        pass
+
+    def get_file_meta(self, owner, repo, path, ref):
+        return ('id: TC-P1\ntitle: "old"\n', "blobsha")  # matches source_body → no conflict
+
+    def put_file(self, owner, repo, path, content, message, branch, sha=None):
+        self.written = {"path": path, "content": content, "branch": branch, "sha": sha}
+        return "newsha999"
+
+
+class _FakeGL:
+    instance = None
+
+    def __init__(self, *a, **k):
+        _FakeGL.instance = self
+        self.written = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        pass
+
+    def get_file_opt(self, project, path, ref):
+        return 'id: TC-P1\ntitle: "old"\n'
+
+    def write_file(self, project, path, content, branch, message, update):
+        self.written = {"path": path, "content": content, "branch": branch, "update": update}
+
+    def latest_commit(self, project, branch):
+        return "glnewsha"
+
+
+# ── github push_test ────────────────────────────────────────────
+
+def test_github_push_test_commits_and_updates_row(db, monkeypatch):
+    monkeypatch.setattr(github_sync, "GitHubClient", _FakeGH)
+    t = _make_test(db, title="edited in ThoroTest")
+    intg = models.Integration(id="i1", name="GH", type="vcs_ci", icon="github",
+                              config={"repo_url": t.repo_url, "branch": "main", "token": "ghp"})
+
+    stats = github_sync.push_test(db, intg, t)
+    assert stats["committed"] is True
+    assert stats["commit"] == "newsha999"
+    assert stats["path"] == "tests/a.yml"
+    # written YAML reflects the edited title; row advanced to the new commit
+    assert "edited in ThoroTest" in _FakeGH.instance.written["content"]
+    assert _FakeGH.instance.written["sha"] == "blobsha"
+    assert t.source_ref == "newsha999"
+    assert "edited in ThoroTest" in t.source_body
+
+
+def test_github_push_test_conflict(db, monkeypatch):
+    class _Diverged(_FakeGH):
+        def get_file_meta(self, owner, repo, path, ref):
+            return ("someone changed this on git", "blobsha")
+
+    monkeypatch.setattr(github_sync, "GitHubClient", _Diverged)
+    t = _make_test(db)
+    intg = models.Integration(id="i2", name="GH", type="vcs_ci", icon="github",
+                              config={"repo_url": t.repo_url, "branch": "main"})
+    with pytest.raises(git_push.PushConflict):
+        github_sync.push_test(db, intg, t)
+    assert t.source_ref == "oldsha"   # unchanged on conflict
+
+
+# ── gitlab push_test ────────────────────────────────────────────
+
+def test_gitlab_push_test_commits_and_updates_row(db, monkeypatch):
+    monkeypatch.setattr(gitlab_sync, "GitLabClient", _FakeGL)
+    t = _make_test(db, id="TC-GL", repo_url="https://gitlab.com/acme/web",
+                   title="gl edit")
+    intg = models.Integration(id="i3", name="GL", type="vcs_ci", icon="gitlab",
+                              config={"provider": "gitlab", "repo_url": t.repo_url,
+                                      "branch": "main", "token": "glpat"})
+    stats = gitlab_sync.push_test(db, intg, t)
+    assert stats["commit"] == "glnewsha"
+    assert _FakeGL.instance.written["update"] is True
+    assert "gl edit" in _FakeGL.instance.written["content"]
+    assert t.source_ref == "glnewsha"
+
+
+# ── endpoint ────────────────────────────────────────────────────
+
+def test_push_endpoint_dispatches_to_provider(client, db, monkeypatch):
+    monkeypatch.setattr(github_sync, "GitHubClient", _FakeGH)
+    _make_test(db, id="TC-EP")
+    db.add(models.Integration(id="i-ep", name="GH", type="vcs_ci", icon="github",
+                              config={"repo_url": "https://github.com/acme/web",
+                                      "branch": "main", "token": "ghp"}))
+    db.commit()
+    r = client.post("/api/tests/TC-EP/push-to-git")
+    assert r.status_code == 200, r.text
+    assert r.json()["commit"] == "newsha999"
+
+
+def test_push_endpoint_conflict_returns_409(client, db, monkeypatch):
+    class _Diverged(_FakeGH):
+        def get_file_meta(self, owner, repo, path, ref):
+            return ("changed on git", "blobsha")
+
+    monkeypatch.setattr(github_sync, "GitHubClient", _Diverged)
+    _make_test(db, id="TC-EP2")
+    db.add(models.Integration(id="i-ep2", name="GH", type="vcs_ci", icon="github",
+                              config={"repo_url": "https://github.com/acme/web", "branch": "main"}))
+    db.commit()
+    r = client.post("/api/tests/TC-EP2/push-to-git")
+    assert r.status_code == 409, r.text
+
+
+def test_push_endpoint_rejects_non_git_test(client, db):
+    _make_test(db, id="TC-NOSRC", repo_url=None, source_path=None)
+    r = client.post("/api/tests/TC-NOSRC/push-to-git")
+    assert r.status_code == 400
+
+
+def test_push_endpoint_no_matching_integration(client, db):
+    _make_test(db, id="TC-NOINT", repo_url="https://github.com/nomatch/repo")
+    r = client.post("/api/tests/TC-NOINT/push-to-git")
+    assert r.status_code == 400
+
+
+# ── A↔B link: CI run results attach to the YAML scheda ──────────
+
+# Convention: the case id appears bracketed or as a trailing token — not
+# mid-word before an English word (that boundary is ambiguous).
+@pytest.mark.parametrize("parts,expected", [
+    (("login [TC-GL-100]",), "TC-GL-100"),
+    (("test_login_TC_GL_100",), "TC-GL-100"),
+    (("TC-GL-100",), "TC-GL-100"),
+    (("plain name", "pkg.TC-42.Case"), "TC-42"),
+    (("no id here", "also none"), ""),
+])
+def test_extract_case_id(parts, expected):
+    assert extract_case_id(*parts) == expected
+
+
+# Regression: "TC" must be a real id prefix, not any word starting with TC.
+# A missing separator or a preceding alnum char must NOT match.
+@pytest.mark.parametrize("s", [
+    "test_TCP_connection",   # TCP — no separator after TC
+    "TContext setup",        # word starting TC
+    "BTC-100 wallet",        # TC inside "BTC" — preceded by alnum
+    "test_tcp_handshake",    # lowercase, not the TC- convention
+    "matcher",               # no TC at all
+])
+def test_extract_case_id_no_false_positive(s):
+    assert extract_case_id(s) == ""
+
+
+def test_junit_parse_sets_source_id():
+    xml = (b'<testsuite name="e2e"><testcase name="login [TC-GL-100]" classname="e2e/login"/>'
+           b'</testsuite>')
+    result = parse_junit_xml(xml)
+    assert result.tests[0].source_id == "TC-GL-100"
+    assert result.runs[0].cases[0].source_test_id == "TC-GL-100"
+
+
+def test_gitlab_test_report_sets_source_id():
+    report = {"test_suites": [{"name": "e2e", "test_cases": [
+        {"name": "login [TC-GL-100]", "classname": "e2e/login", "status": "failed"},
+    ]}]}
+    result = gitlab_actions.parse_test_report(report, "pipeline #1")
+    assert result.tests[0].source_id == "TC-GL-100"
+    assert result.runs[0].cases[0].source_test_id == "TC-GL-100"
+
+
+def test_sync_tags_scheda_with_ci_identity(db):
+    files = [("tests/login.yml", 'id: TC-GL-100\ntitle: "Login"\ntype: automated\n')]
+    github_sync.sync_repo(db, "https://gitlab.com/a/b", "main", "", None,
+                          fetcher=lambda *a: ("sha1", files), link_provider="gitlab-ci")
+    t = db.query(models.Test).filter_by(id="TC-GL-100").first()
+    assert t.external_provider == "gitlab-ci"
+    assert t.external_key == "TC-GL-100"
+    assert t.status == "pending"   # not taken from YAML
+
+
+def test_ci_run_links_to_scheda_no_duplicate_and_updates_status(db):
+    # A: sync the scheda (status pending, tagged for gitlab-ci)
+    files = [("tests/login.yml", 'id: TC-GL-100\ntitle: "Login scheda"\ntype: automated\n')]
+    github_sync.sync_repo(db, "https://gitlab.com/a/b", "main", "", None,
+                          fetcher=lambda *a: ("sha1", files), link_provider="gitlab-ci")
+
+    # B: a pipeline result whose case carries the same TC id
+    result = ImportResult(
+        tests=[TD(title="login e2e", type="automated", status="fail", source_id="TC-GL-100")],
+        runs=[RunData(name="pipeline #1", status="done",
+                      cases=[CaseResult(test_title="login e2e", status="fail", source_test_id="TC-GL-100")])],
+    )
+    stats = persist_import_result(db, result, "gitlab-ci", conflict="skip", sync_status=True)
+
+    # no duplicate test created — the run linked to the existing scheda
+    linked = db.query(models.Test).filter_by(external_key="TC-GL-100").all()
+    assert len(linked) == 1
+    assert stats["tests"] == 0 and stats["skipped"] >= 1
+    # the scheda now reflects the real run status
+    assert linked[0].id == "TC-GL-100"
+    assert linked[0].status == "fail"
+    # and a RunCase links the run to it
+    rc = db.query(models.RunCase).filter_by(test_id="TC-GL-100").first()
+    assert rc is not None and rc.status == "fail"
+
+
+def test_ci_run_without_id_falls_back_and_creates_own_test(db):
+    # No scheda synced, no TC id → B creates its own automated test (today's behavior)
+    result = ImportResult(
+        tests=[TD(title="orphan test", type="automated", status="pass")],
+        runs=[RunData(name="run", status="done",
+                      cases=[CaseResult(test_title="orphan test", status="pass")])],
+    )
+    stats = persist_import_result(db, result, "gitlab-ci", conflict="skip", sync_status=True)
+    assert stats["tests"] == 1
+    assert db.query(models.Test).filter_by(title="orphan test").count() == 1

--- a/backend/tests/test_gitlab_e2e_integration.py
+++ b/backend/tests/test_gitlab_e2e_integration.py
@@ -1,0 +1,135 @@
+"""Live end-to-end integration test against a real GitLab CE instance.
+
+This exercises the network-boundary code the unit tests deliberately stub out
+(the GitLab REST wrappers, the pipeline trigger/poll/collect path, and the
+reverse push) against a running GitLab, in-process — no uvicorn needed.
+
+It SKIPS unless a live GitLab is reachable AND a token is provided, so a normal
+`pytest` run is unaffected. To run it:
+
+    cd demo/gitlab && docker compose up -d && ./setup.sh   # prints a glpat-… token
+    export GITLAB_E2E_TOKEN=glpat-…
+    ./venv/bin/python -m pytest backend/tests/test_gitlab_e2e_integration.py -v
+
+Optional overrides: GITLAB_E2E_URL (default http://localhost:8929),
+GITLAB_E2E_REPO (default <url>/root/thorotest-demo). The repo must be the demo
+fixtures (schede TC-GL-100/101 + a .gitlab-ci.yml). The pipeline job pulls a
+docker image on first run, so the first execution can take a few minutes.
+"""
+import os
+import time
+import urllib.error
+import urllib.request
+
+import pytest
+
+from backend import models, gitlab_sync, git_push
+from backend.gitlab_actions import (
+    GitLabActionsClient, ci_config, collect_pipeline_results, _TERMINAL,
+)
+from backend.gitlab_sync import GitLabClient, parse_gitlab_repo
+
+GL_WEB = os.environ.get("GITLAB_E2E_URL", "http://localhost:8929")
+TOKEN = os.environ.get("GITLAB_E2E_TOKEN")
+REPO = os.environ.get("GITLAB_E2E_REPO", f"{GL_WEB}/root/thorotest-demo")
+LOGIN_YML = "tests/auth/login.yml"
+PIPELINE_TIMEOUT = 600
+
+
+def _gitlab_up() -> bool:
+    try:
+        urllib.request.urlopen(f"{GL_WEB}/api/v4/version", timeout=3)
+    except urllib.error.HTTPError as e:
+        return e.code in (200, 401)   # 401 = up but unauthenticated
+    except Exception:
+        return False
+    return True
+
+
+if not (TOKEN and _gitlab_up()):
+    pytest.skip(
+        "live GitLab + GITLAB_E2E_TOKEN required (see module docstring)",
+        allow_module_level=True,
+    )
+
+pytestmark = pytest.mark.integration
+
+
+def _cfg() -> dict:
+    return {"provider": "gitlab", "repo_url": REPO, "api_base": f"{GL_WEB}/api/v4",
+            "branch": "main", "path": "tests/", "token": TOKEN}
+
+
+def _integration(db, iid: str):
+    intg = models.Integration(id=iid, name="GitLab E2E", type="vcs_ci", icon="gitlab",
+                              config=_cfg())
+    db.add(intg)
+    db.commit()
+    return intg
+
+
+def test_sync_then_ci_links_and_updates_status(db):
+    intg = _integration(db, "gl-e2e-1")
+
+    # A: sync the YAML schede — definitions only, status pending, tagged for CI
+    stats = gitlab_sync.sync_integration(db, intg)
+    assert stats["created"] >= 2
+    for tc in ("TC-GL-100", "TC-GL-101"):
+        t = db.query(models.Test).filter_by(id=tc).first()
+        assert t is not None, f"{tc} not synced"
+        assert t.status == "pending"
+        assert t.external_provider == "gitlab-ci" and t.external_key == tc
+
+    # B: run the real pipeline and import its result
+    cfg = ci_config(intg)
+    with GitLabActionsClient(cfg["api_base"], cfg["token"]) as cl:
+        pipe = cl.trigger_pipeline(cfg["project"], cfg["ref"])
+        pid = pipe["id"]
+        deadline = time.time() + PIPELINE_TIMEOUT
+        while time.time() < deadline:
+            detail = cl.get_pipeline(cfg["project"], pid)
+            if detail.get("status") in _TERMINAL:
+                break
+            time.sleep(8)
+        else:
+            pytest.fail("pipeline did not finish in time")
+        collect_pipeline_results(db, cl, cfg["project"], pid, "E2E integration run")
+
+    # the schede now carry the REAL run status, and no duplicate was created
+    for tc in ("TC-GL-100", "TC-GL-101"):
+        t = db.query(models.Test).filter_by(id=tc).first()
+        assert t.status == "pass", f"{tc} status={t.status}"
+        assert db.query(models.Test).filter_by(external_key=tc).count() == 1
+
+
+def test_push_roundtrip_and_conflict(db):
+    intg = _integration(db, "gl-e2e-2")
+    gitlab_sync.sync_integration(db, intg)
+    t = db.query(models.Test).filter_by(id="TC-GL-100").first()
+    original_body = t.source_body
+    api_base, project = parse_gitlab_repo(REPO, f"{GL_WEB}/api/v4")
+
+    try:
+        # edit in ThoroTest → push → the file on git reflects it, no status field
+        t.title = "Edited by integration test"
+        db.commit()
+        gitlab_sync.push_test(db, intg, t)
+        with GitLabClient(api_base, TOKEN) as gl:
+            content = gl.get_file(project, LOGIN_YML, "main")
+        assert "Edited by integration test" in content
+        assert "status:" not in content
+
+        # diverge the file out-of-band → next push must 409 (PushConflict)
+        with GitLabClient(api_base, TOKEN) as gl:
+            gl.write_file(project, LOGIN_YML, content + "\n# out-of-band\n", "main",
+                          "diverge", update=True)
+        t.title = "Edited again"
+        db.commit()
+        with pytest.raises(git_push.PushConflict):
+            gitlab_sync.push_test(db, intg, t)
+    finally:
+        # restore the fixture so the demo repo is left clean
+        with GitLabClient(api_base, TOKEN) as gl:
+            cur = gl.get_file_opt(project, LOGIN_YML, "main")
+            gl.write_file(project, LOGIN_YML, original_body, "main",
+                          "restore fixture", update=cur is not None)

--- a/demo/gitlab/README.md
+++ b/demo/gitlab/README.md
@@ -50,9 +50,26 @@ JUnit report (`artifacts: reports: junit:`, `when: always`):
 - **playwright** — [`repo/e2e/`](repo/e2e/), one intentional failure.
 
 So the pipeline goes **red** (playwright fails), yet ThoroTest still imports the
-full breakdown — **5 pass / 1 fail** — because the reports publish even on
-failure. Change the assertions to make it all green, or move the failure between
-jobs, to reshape the demo.
+full breakdown because the reports publish even on failure. Change the
+assertions to make it all green, or move the failure between jobs, to reshape
+the demo.
+
+## Sync + CI: one test, one source of truth
+
+The playwright titles carry `[TC-GL-100]` / `[TC-GL-101]` tokens that match the
+`id:` of the YAML schede under [`repo/tests/`](repo/tests/). This links the two
+sides:
+
+1. **Sync** (pull) creates the schede `TC-GL-100` / `TC-GL-101` — definitions
+   only (title, owner, priority). Their status starts `pending`; the YAML has
+   **no** `status:` field, because a hand-written status can lie.
+2. **Run CI** imports the pipeline result. Each case's `[TC-GL-…]` token is
+   matched to its scheda, so the run attaches to the **same** test row (no
+   duplicate) and advances its status to the **real** result.
+
+So after Sync then Run CI, `TC-GL-100` flips `pending → pass` from the actual
+run. Cases without a token (e.g. "apple pay …") still import as their own
+automated tests — the token is opt-in.
 
 ## Networking note
 

--- a/demo/gitlab/repo/e2e/checkout.spec.ts
+++ b/demo/gitlab/repo/e2e/checkout.spec.ts
@@ -3,12 +3,22 @@ import { test, expect } from '@playwright/test';
 // Pure-assertion e2e demo (no app/browser needed) so the pipeline is fast and
 // deterministic. One test fails on purpose → the playwright job goes red while
 // the pytest job stays green.
+//
+// The [TC-GL-…] tokens in the titles are the correlation ids: they match the
+// `id:` of the YAML schede under tests/. When the pipeline result is imported,
+// ThoroTest links each case to its scheda (no duplicate) and updates the
+// scheda's status to the real run result — so status lives here, not in the
+// hand-written YAML.
 test.describe('checkout', () => {
+  test('login with valid credentials [TC-GL-100]', async () => {
+    expect(200).toBe(200);
+  });
+
   test('guest checkout succeeds', async () => {
     expect(200).toBe(200);
   });
 
-  test('promo code applies discount', async () => {
+  test('promo code applies discount [TC-GL-101]', async () => {
     const total = 100 * (1 - 0.1);
     expect(total).toBeCloseTo(90);
   });

--- a/demo/gitlab/repo/tests/auth/login.yml
+++ b/demo/gitlab/repo/tests/auth/login.yml
@@ -2,7 +2,6 @@ id: TC-GL-100
 title: "Login with valid credentials"
 type: e2e
 runner: playwright
-status: passed
 priority: P1
 owner: qa@acme.com
 tags: [smoke, auth]

--- a/demo/gitlab/repo/tests/checkout/promo.yml
+++ b/demo/gitlab/repo/tests/checkout/promo.yml
@@ -2,7 +2,6 @@ id: TC-GL-101
 title: "Promo code applies discount at checkout"
 type: e2e
 runner: playwright
-status: pending
 priority: P2
 owner: qa@acme.com
 tags: [checkout, payment]

--- a/docs/gitlab-ci.md
+++ b/docs/gitlab-ci.md
@@ -1,0 +1,179 @@
+# Running tests in GitLab CI
+
+ThoroTest can drive a project's **GitLab CI** end to end: it creates a pipeline,
+waits for it to finish, reads the pipeline's **test report**, and imports the
+results as a run — real pass/fail, no simulation. Works with **gitlab.com** and
+**self-hosted** GitLab.
+
+This is a **pull** model: ThoroTest reaches out to GitLab. (If you'd rather have
+CI push results in, see [Alternative: push from CI](#alternative-push-from-ci).)
+
+```
+Run CI  ──create pipeline──▶  GitLab CI pipeline
+   ▲                              │ runs your jobs (junit reports)
+   │                              ▼
+ThoroTest  ◀──poll──────────  pipeline  ──finished──▶  GET test_report
+   │
+   └─ parse report → import as a run (Runs & plans ▸ History)
+```
+
+Simpler than the GitHub Actions flow: creating a pipeline returns its id
+immediately (no "find the dispatched run" step), and results come from the
+structured `test_report` endpoint, so there's no artifact to name or download —
+your jobs just have to publish JUnit reports.
+
+## Prerequisites
+
+- A GitLab repository whose `.gitlab-ci.yml` jobs publish JUnit reports
+  (`artifacts: reports: junit:`).
+- A GitLab **personal access token (PAT)** with the **`api`** scope (needed to
+  create a pipeline; `read_api` is enough for read-only *sync* but not to run CI).
+- A GitLab integration configured in ThoroTest with that repo + token.
+- A registered **runner** for the project (gitlab.com shared runners, or your own).
+
+## Step 1 — Prepare `.gitlab-ci.yml`
+
+Each job that produces tests must publish a JUnit report. Use `when: always` so
+results are published even when a job fails.
+
+```yaml
+stages: [test]
+
+pytest:
+  stage: test
+  image: python:3.12-slim
+  script:
+    - pip install -r requirements.txt pytest
+    - pytest --junitxml=report.xml
+  artifacts:
+    when: always
+    reports:
+      junit: report.xml
+
+playwright:
+  stage: test
+  image: mcr.microsoft.com/playwright:v1.48.0-jammy
+  script:
+    - npm ci
+    - npx playwright test --reporter=junit
+  artifacts:
+    when: always
+    reports:
+      junit: results.xml
+```
+
+Any tool that emits JUnit XML works. ThoroTest aggregates every job's report into
+one run.
+
+> **Link results to your test schede.** If you keep tests as YAML (see the main
+> README's *Tests as Code*), put each scheda's `id` in the automated test's name,
+> e.g. a Playwright title `login with valid credentials [TC-GL-100]`. On import,
+> ThoroTest matches the `TC-…` token to the scheda — attaching the run to the same
+> test row (no duplicate) and updating its status to the real result.
+
+## Step 2 — Create a GitLab token
+
+GitLab ▸ **User settings ▸ Access tokens** (or a project/group token):
+
+- Scope **`api`** — required to create a pipeline (Run CI). For read-only *sync*
+  of YAML tests, `read_api` suffices.
+
+Copy the token (`glpat-…`); you'll paste it into ThoroTest.
+
+## Step 3 — Configure the integration
+
+In ThoroTest: **Configure ▸ Integrations ▸ Add ▸ GitLab** (or edit an existing
+GitLab integration):
+
+| Field | Value |
+|---|---|
+| Provider | `gitlab` — **required** for self-hosted hosts (can't be inferred) |
+| Repository URL | `https://gitlab.com/your-group/your-repo` |
+| API base | _(self-hosted, optional)_ e.g. `https://gitlab.internal/api/v4`; derived from the repo URL when omitted |
+| Branch | the ref to run, e.g. `main` |
+| Personal access token | the PAT from Step 2 |
+
+Save. The token is stored server-side and never returned to the browser.
+
+## Step 4 — Run it
+
+On the integration's row, click **Run CI**. The status updates inline:
+
+```
+dispatching…  →  running…  →  collecting…  →  imported 6 tests · 1 run
+```
+
+Behind the scenes ThoroTest creates the pipeline, polls every 15 s until it
+reaches a terminal state, reads its `test_report`, and imports it. The dispatch
+also appears on the **Pipelines** page (running → pass/fail, with commit, branch,
+and duration).
+
+## Step 5 — See the results
+
+- **Runs & plans ▸ History** — a new run with the real pass/fail results.
+- **Library** — folders built from each test's `classname`.
+- **Pipelines** — the pipeline run alongside your other CI history.
+- If you tagged tests with `[TC-…]` ids, their **schede flip from `pending` to the
+  real status**.
+
+Re-running is idempotent for test definitions: tests are matched by identity and
+updated in place rather than duplicated.
+
+## Using the API (no UI)
+
+```bash
+# Trigger (provider is read from the integration config)
+JOB=$(curl -sf -X POST "$THOROTEST/api/integrations/$INTEGRATION_ID/ci/run" \
+  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+  -d '{"ref":"main","run_name":"CI #42"}' | jq -r .job_id)
+
+# Poll
+curl -sf "$THOROTEST/api/integrations/$INTEGRATION_ID/ci/jobs/$JOB" \
+  -H "Authorization: Bearer $TOKEN"
+# → {"status":"running", ...} → {"status":"done","imported":{"tests":6,"runs":1}}
+```
+
+`ref` and `run_name` are optional overrides; without them the integration's
+configured values are used.
+
+## Troubleshooting
+
+| Message | Likely cause |
+|---|---|
+| `Dispatch failed (400/404)` | no `.gitlab-ci.yml`, wrong ref, or the project can't create a pipeline |
+| `gitlab auth error (401/403)` | PAT missing, expired, or lacks the `api` scope |
+| `pipeline did not complete within timeout` | the pipeline took longer than 30 min (e.g. no runner available) |
+| empty / partial results | a job didn't declare `artifacts: reports: junit:`, or failed before publishing (use `when: always`) |
+| `cannot determine VCS provider` | self-hosted host with no explicit `provider` — set it to `gitlab` |
+
+## Limitations
+
+- Job tracking is in-memory: restarting the server mid-run loses the tracking
+  (the GitLab pipeline itself continues).
+- Results are imported once the pipeline finishes; per-test live streaming is not
+  (yet) supported.
+
+## Try it locally
+
+A fully dockerised demo — GitLab CE + a runner + a seeded repo with YAML schede
+and a `.gitlab-ci.yml` — lives in **[demo/gitlab/](../demo/gitlab/)**. Bring it up,
+run `setup.sh`, and it prints the exact integration config (including a minted
+token) to paste into ThoroTest.
+
+## Alternative: push from CI
+
+If you'd rather not give ThoroTest a token, have your CI **push** results in at
+the end of its job:
+
+```yaml
+publish:
+  stage: .post
+  script:
+    - |
+      curl -sf -X POST "$THOROTEST_URL/api/import/execute" \
+        -H "Authorization: Bearer $THOROTEST_TOKEN" \
+        -F "file=@report.xml" -F "format=junit_xml"
+```
+
+This needs a ThoroTest API token and a reachable ThoroTest instance, but no
+GitLab PAT.

--- a/e2e/suite14-extra/extra.spec.ts
+++ b/e2e/suite14-extra/extra.spec.ts
@@ -288,9 +288,15 @@ test.describe('Suite 14 — Extra Coverage, Edge Cases & Library Gaps', () => {
   // EXTRA-17 · Pipelines — verify data from API not hardcoded [P2]
   test('EXTRA-17: pipelines page shows data from /api/initial-data', async ({ page }) => {
     await loginAs(page, 'marco@acme.com');
-
-    // Verify initial-data has pipelines
     const token = await getToken(page);
+
+    // Pipelines aren't seeded, so record one via the API (as CI would), then
+    // verify the page renders exactly what the API returns — not hardcoded.
+    await page.request.post(`${BASE}/api/pipelines`, {
+      headers: { Authorization: `Bearer ${token}` },
+      data: { id: 'wf-e2e-1', name: 'e2e.yml — check', platform: 'github', status: 'pass' },
+    });
+
     const res = await page.request.get(`${BASE}/api/initial-data`, {
       headers: { Authorization: `Bearer ${token}` },
     });

--- a/e2e/suite7-pipelines/pipelines.spec.ts
+++ b/e2e/suite7-pipelines/pipelines.spec.ts
@@ -7,20 +7,19 @@ test.describe('Suite 7 — Pipelines', () => {
     await loginAs(page, 'marco@acme.com');
   });
 
-  // E2E-PIPE-01 · Lista pipeline [P2]
-  test('PIPE-01: lista pipeline caricata', async ({ page }) => {
+  // E2E-PIPE-01 · Pagina pipeline [P2]
+  test('PIPE-01: pagina pipeline caricata', async ({ page }) => {
     await page.click('.nav-item:has-text("CI pipelines")');
     await page.waitForURL('**/#/pipelines', { timeout: 5000 });
     await expect(page.locator('.app')).toHaveAttribute('data-screen-label', 'pipelines');
 
-    // At least 6 pipeline rows/items
-    await expect(page.locator('.table tr').first()).toBeVisible({ timeout: 10000 });
-    const rows = await page.locator('.table tr').count();
-    expect(rows).toBeGreaterThanOrEqual(6);
-
-    // Status badges present (pass/fail/running)
-    const badges = await page.locator('.status, [class*="status"]').count();
-    expect(badges).toBeGreaterThan(0);
+    // Pipelines are not seeded: a fresh instance shows the empty state, but
+    // another test may have recorded a run — accept either (empty state OR rows).
+    await expect(async () => {
+      const empty = await page.locator('.empty', { hasText: 'No pipeline runs yet' }).count();
+      const rows = await page.locator('.table tbody tr').count();
+      expect(empty > 0 || rows > 0).toBeTruthy();
+    }).toPass({ timeout: 10000 });
   });
 
 });

--- a/frontend/api.js
+++ b/frontend/api.js
@@ -349,6 +349,16 @@
       return res.json();
     },
 
+    async pushTestToGit(id) {
+      const res = await fetch(BASE + `/api/tests/${id}/push-to-git`, { method: "POST", headers: authHeaders() });
+      if (!res.ok) {
+        let msg = "Push to git failed";
+        try { msg = (await res.json()).detail || msg; } catch {}
+        throw new Error(msg);
+      }
+      return res.json();
+    },
+
     async getRunDefects(runId) {
       const res = await fetch(BASE + `/api/runs/${runId}/defects`, { headers: authHeaders() });
       if (!res.ok) throw new Error("Run defects fetch failed");

--- a/frontend/api.js
+++ b/frontend/api.js
@@ -604,6 +604,11 @@
       if (!res.ok && res.status !== 204) { const e = await res.json().catch(() => ({})); throw new Error(e.detail || "Delete failed"); }
     },
 
+    async deletePipeline(id) {
+      const res = await fetch(BASE + `/api/pipelines/${id}`, { method: "DELETE", headers: authHeaders() });
+      if (!res.ok && res.status !== 204) { const e = await res.json().catch(() => ({})); throw new Error(e.detail || "Delete failed"); }
+    },
+
     async syncIntegration(id) {
       const res = await fetch(BASE + `/api/integrations/${id}/sync`, { method: "POST", headers: authHeaders() });
       if (!res.ok) { const e = await res.json().catch(() => ({})); throw new Error(e.detail || "Sync failed"); }

--- a/frontend/app.jsx
+++ b/frontend/app.jsx
@@ -228,7 +228,10 @@ function App({ currentUser: initialUser, onLogout, onProfileUpdate }) {
 
       <TweaksPanel title="Tweaks">
         <TweakSection label="Appearance">
-          <TweakRadio label="Theme" value={tweaks.theme} onChange={v => setTweak("theme", v)} options={[
+          <TweakRadio label="Theme" value={theme} onChange={v => {
+            setTheme(v);
+            try { localStorage.setItem("tt-theme", v); } catch (e) {}
+          }} options={[
             { value: "dark", label: "Dark" },
             { value: "light", label: "Light" },
           ]} />

--- a/frontend/app.jsx
+++ b/frontend/app.jsx
@@ -52,6 +52,19 @@ function buildHash(view, testId, runId) {
 
 function App({ currentUser: initialUser, onLogout, onProfileUpdate }) {
   const [tweaks, setTweak] = useTweaks(TWEAK_DEFAULTS);
+  // Theme is user-toggleable from the topbar and persisted (the Tweaks panel
+  // isn't reachable in the standalone app, so it can't own this).
+  const [theme, setTheme] = React.useState(() => {
+    try { return localStorage.getItem("tt-theme") || TWEAK_DEFAULTS.theme; }
+    catch (e) { return TWEAK_DEFAULTS.theme; }
+  });
+  const toggleTheme = React.useCallback(() => {
+    setTheme(t => {
+      const next = t === "dark" ? "light" : "dark";
+      try { localStorage.setItem("tt-theme", next); } catch (e) {}
+      return next;
+    });
+  }, []);
   const initial = parseHash(window.location.hash);
   const safeInitialView = (initial.view === "admin" && initialUser?.role !== "admin") ? "overview" : initial.view;
   const [view, setView] = useState(safeInitialView);
@@ -72,9 +85,9 @@ function App({ currentUser: initialUser, onLogout, onProfileUpdate }) {
 
   // Apply theme + density to <html>
   useEffect(() => {
-    document.documentElement.setAttribute("data-theme", tweaks.theme);
+    document.documentElement.setAttribute("data-theme", theme);
     document.documentElement.setAttribute("data-density", tweaks.density);
-  }, [tweaks.theme, tweaks.density]);
+  }, [theme, tweaks.density]);
 
   // Sync URL hash when view/id changes
   useEffect(() => {
@@ -205,7 +218,7 @@ function App({ currentUser: initialUser, onLogout, onProfileUpdate }) {
     <div className="app" data-screen-label={view}>
       <Sidebar current={view === "test-detail" ? "library" : view === "run-detail" ? "runs" : view} onNav={nav} onOpenTest={openTest} density={tweaks.density} currentUser={currentUser} onLogout={onLogout} />
       <div className="main">
-        {!hideTopbar && <Topbar crumbs={crumbs} actions={actions} />}
+        {!hideTopbar && <Topbar crumbs={crumbs} actions={actions} theme={theme} onToggleTheme={toggleTheme} />}
         <div className="content" style={hideTopbar ? {} : {}}>
           {body}
         </div>

--- a/frontend/components/app-shell.jsx
+++ b/frontend/components/app-shell.jsx
@@ -223,8 +223,7 @@ function Sidebar({ current, onNav, onOpenTest, density, currentUser, onLogout })
   );
 }
 
-function Topbar({ crumbs, actions }) {
-  const { t } = useI18n();
+function Topbar({ crumbs, actions, theme, onToggleTheme }) {
   return (
     <div className="topbar">
       <div className="breadcrumb">
@@ -242,9 +241,13 @@ function Topbar({ crumbs, actions }) {
       </div>
       <div className="topbar-right">
         {actions}
-        <span className="kbd">⌘</span>
-        <span className="kbd">N</span>
-        <span className="muted" style={{fontSize:11.5, marginLeft:4}}>{t("common.newTest")}</span>
+        {onToggleTheme && (
+          <button className="btn ghost icon sm" onClick={onToggleTheme}
+                  title={theme === "dark" ? "Switch to light theme" : "Switch to dark theme"}
+                  aria-label="Toggle theme">
+            <Icon name={theme === "dark" ? "sun" : "moon"} />
+          </button>
+        )}
       </div>
     </div>
   );

--- a/frontend/components/icons.jsx
+++ b/frontend/components/icons.jsx
@@ -31,6 +31,8 @@ const I = {
   upload: <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round"><path d="M12 15V3m0 0-4 4m4-4 4 4M4 17v2a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-2"/></svg>,
   logout: <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4M16 17l5-5-5-5M21 12H9"/></svg>,
   target: <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="9"/><circle cx="12" cy="12" r="5"/><circle cx="12" cy="12" r="1.5"/></svg>,
+  sun: <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2m0 16v2M4.9 4.9l1.4 1.4m11.4 11.4 1.4 1.4M2 12h2m16 0h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg>,
+  moon: <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round"><path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z"/></svg>,
 };
 
 function Icon({name, className}) {

--- a/frontend/views/view-misc.jsx
+++ b/frontend/views/view-misc.jsx
@@ -21,6 +21,17 @@ function Pipelines() {
     return () => clearInterval(id);
   }, [anyRunning]);
 
+  async function del(id, name, e) {
+    e.stopPropagation();   // don't also open the run URL
+    if (!window.confirm(`Remove pipeline "${name}" from the list? (the run on the CI provider is untouched)`)) return;
+    try {
+      await TH_API.deletePipeline(id);
+      setRows(rs => (rs || []).filter(p => p.id !== id));
+    } catch (err) {
+      window.alert(err.message);
+    }
+  }
+
   if (loading) return (
     <div className="page fade-in">
       <div className="empty">Loading…</div>
@@ -71,6 +82,7 @@ function Pipelines() {
                 <th style={{width:100}}>Branch</th>
                 <th style={{width:120}}>Author</th>
                 <th style={{width:100}}>When</th>
+                <th style={{width:40}}></th>
               </tr>
             </thead>
             <tbody>
@@ -91,6 +103,12 @@ function Pipelines() {
                   <td className="mono dim">{p.branch}</td>
                   <td className="mono dim">{p.author}</td>
                   <td className="mono dim">{p.when}</td>
+                  <td>
+                    <button className="btn ghost icon sm" title="Remove from list"
+                            onClick={e => del(p.id, p.name, e)}>
+                      {I.x}
+                    </button>
+                  </td>
                 </tr>
               ))}
             </tbody>

--- a/frontend/views/view-misc.jsx
+++ b/frontend/views/view-misc.jsx
@@ -105,6 +105,7 @@ function Pipelines() {
                   <td className="mono dim">{p.when}</td>
                   <td>
                     <button className="btn ghost icon sm" title="Remove from list"
+                            style={{color:"var(--fail)"}}
                             onClick={e => del(p.id, p.name, e)}>
                       {I.x}
                     </button>

--- a/frontend/views/view-misc.jsx
+++ b/frontend/views/view-misc.jsx
@@ -75,13 +75,16 @@ function Pipelines() {
             </thead>
             <tbody>
               {list.map(p => (
-                <tr key={p.id} style={{cursor:"pointer"}}>
+                <tr key={p.id}
+                    style={p.url ? {cursor:"pointer"} : undefined}
+                    title={p.url ? "Open the run on the CI provider" : undefined}
+                    onClick={p.url ? () => window.open(p.url, "_blank", "noopener,noreferrer") : undefined}>
                   <td>
                     <span style={{display:"inline-flex", width:18, height:18}}>
                       {p.platform === "github" ? I.github : p.platform === "gitlab" ? I.gitlab : I.jenkins}
                     </span>
                   </td>
-                  <td>{p.name}</td>
+                  <td>{p.name}{p.url && <span className="dim" style={{marginLeft:6, fontSize:11}}>↗</span>}</td>
                   <td><StatusBadge s={p.status} /></td>
                   <td className="mono dim">{p.duration}</td>
                   <td className="mono" style={{color:"var(--accent)"}}>{p.commit}</td>

--- a/frontend/views/view-misc.jsx
+++ b/frontend/views/view-misc.jsx
@@ -107,7 +107,7 @@ function Pipelines() {
                     <button className="btn ghost icon sm" title="Remove from list"
                             style={{color:"var(--fail)"}}
                             onClick={e => del(p.id, p.name, e)}>
-                      {I.x}
+                      <Icon name="x" />
                     </button>
                   </td>
                 </tr>

--- a/frontend/views/view-misc.jsx
+++ b/frontend/views/view-misc.jsx
@@ -2,6 +2,24 @@
 
 function Pipelines() {
   const { data: D, loading, error } = useInitialData();
+  const [rows, setRows] = React.useState(null);
+
+  // Seed the table from initial-data on first load.
+  React.useEffect(() => { if (D?.pipelines) setRows(D.pipelines); }, [D]);
+
+  // While a dispatch is still running, poll so it flips to pass/fail live
+  // (a "Run CI" writes a running row that finishes a bit later).
+  const anyRunning = (rows || []).some(p => p.status === "running");
+  React.useEffect(() => {
+    if (!anyRunning) return;
+    const id = setInterval(async () => {
+      try {
+        const res = await fetch('/api/pipelines', { headers: window.authHeaders() });
+        if (res.ok) setRows(await res.json());
+      } catch {}
+    }, 4000);
+    return () => clearInterval(id);
+  }, [anyRunning]);
 
   if (loading) return (
     <div className="page fade-in">
@@ -15,6 +33,8 @@ function Pipelines() {
     </div>
   );
 
+  const list = rows || D.pipelines;
+
   return (
     <div className="page fade-in">
       <div className="page-h">
@@ -22,6 +42,7 @@ function Pipelines() {
           <h1 className="page-title">CI pipelines</h1>
           <div className="page-sub">Every CI run that touched your tests, alongside the manual results. Same timeline, one source of truth.</div>
         </div>
+        {anyRunning && <div className="card-sub" style={{alignSelf:"center"}}>● live — refreshing…</div>}
       </div>
 
       <div className="card" style={{marginBottom:14}}>
@@ -31,7 +52,7 @@ function Pipelines() {
             <div className="card-sub">CI pipeline results imported into ThoroTest</div>
           </div>
         </div>
-        {D.pipelines.length === 0 ? (
+        {list.length === 0 ? (
           <div className="empty" style={{padding:"48px 18px", textAlign:"center"}}>
             <div style={{fontSize:13, marginBottom:6}}>No pipeline runs yet.</div>
             <div className="mono dim" style={{fontSize:11}}>
@@ -53,7 +74,7 @@ function Pipelines() {
               </tr>
             </thead>
             <tbody>
-              {D.pipelines.map(p => (
+              {list.map(p => (
                 <tr key={p.id} style={{cursor:"pointer"}}>
                   <td>
                     <span style={{display:"inline-flex", width:18, height:18}}>

--- a/frontend/views/view-test-detail.jsx
+++ b/frontend/views/view-test-detail.jsx
@@ -319,7 +319,8 @@ function DefinitionTab({ test, currentUser }) {
         </div>
 
         {/* YAML source — rendered only when this test is synced from git */}
-        {test.source_path && <YamlSourceCard test={test} />}
+        {test.source_path && <YamlSourceCard test={test}
+          onPushed={patch => setTest(t => ({...t, ...patch}))} />}
       </div>
 
       {/* Side column — keep unchanged from original */}
@@ -369,7 +370,9 @@ function Detail({label, value, mono}) {
   );
 }
 
-function YamlSourceCard({test}) {
+function YamlSourceCard({test, onPushed}) {
+  const [pushing, setPushing] = useState(false);
+  const [msg, setMsg] = useState(null);   // {kind: "ok"|"err", text}
   const ref = test.source_ref || "";
   const shortRef = ref.slice(0, 7);
   // {repo_url}/blob/{ref}/{path} → exact file at the synced commit on GitHub.
@@ -379,6 +382,21 @@ function YamlSourceCard({test}) {
   const synced = test.source_synced_at
     ? new Date(test.source_synced_at).toLocaleString()
     : null;
+
+  async function push() {
+    setPushing(true);
+    setMsg(null);
+    try {
+      const r = await TH_API.pushTestToGit(test.id);
+      onPushed && onPushed({ source_ref: r.commit, source_synced_at: new Date().toISOString() });
+      setMsg({ kind: "ok", text: `Pushed · ${(r.commit || "").slice(0, 7)}` });
+    } catch (e) {
+      setMsg({ kind: "err", text: e.message });
+    } finally {
+      setPushing(false);
+    }
+  }
+
   return (
     <div className="card">
       <div className="card-h">
@@ -387,12 +405,22 @@ function YamlSourceCard({test}) {
           synced from git{shortRef ? ` · ${shortRef}` : ""}{synced ? ` · ${synced}` : ""}
         </div>
         <div className="spacer" />
+        <button className="btn sm" onClick={push} disabled={pushing}
+                title="Commit this test's current state back to its source file on git">
+          <Icon name="upload" /> {pushing ? "Pushing…" : "Push to git"}
+        </button>
         {ghUrl && (
           <a className="btn sm" href={ghUrl} target="_blank" rel="noopener noreferrer">
             <Icon name="github" /> View on GitHub
           </a>
         )}
       </div>
+      {msg && (
+        <div style={{padding:"8px 14px 0", fontSize:12,
+                     color: msg.kind === "ok" ? "var(--green, #2e7d32)" : "var(--red, #c62828)"}}>
+          {msg.text}
+        </div>
+      )}
       <div style={{padding:14}}>
         {test.source_body
           ? <pre className="code"><code>{test.source_body}</code></pre>

--- a/migrations/versions/7b2e1c4a9d10_pipeline_url.py
+++ b/migrations/versions/7b2e1c4a9d10_pipeline_url.py
@@ -1,0 +1,24 @@
+"""pipelines.url — link to the run on GitHub/GitLab
+
+Revision ID: 7b2e1c4a9d10
+Revises: 109d742308e8
+Create Date: 2026-07-09 17:20:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '7b2e1c4a9d10'
+down_revision = '109d742308e8'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column('pipelines', sa.Column('url', sa.String(length=512), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('pipelines', 'url')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thorotest",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Source-available test management platform. Organize, run, and track tests across manual and automated suites — one timeline for both.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary

Turns the GitHub/GitLab "Tests as Code" sync into a two-way flow and connects it to CI so a test is one row with a single source of truth per field.

**Reverse sync (ThoroTest → git).** A test's YAML card gains a **Push to git** button that commits the test's current state back to its source file, for both GitHub and GitLab. A conflict guard returns **409** when the file changed on git since the last sync, so a UI edit never silently clobbers a change made on git.

**Link sync (schede) ↔ CI import.** A CI run's results now attach to the same test row the YAML scheda created — no duplicate — and advance the scheda's status to the real run result. The link is a `[TC-…]` correlation id extracted from the automated test's name/class. Because status now comes from real runs, the hand-written `status:` field is gone from the YAML flow (it could lie).

**Pipelines page.** Every "Run CI" dispatch now shows on the Pipelines page (running → pass/fail, with commit/branch/duration), the page live-refreshes while a run is active, a row opens the real run on the provider, and entries can be deleted. The fake demo pipelines are no longer seeded — the page shows only real runs.

**Topbar.** Replaced a dead "⌘ N · New test" hint with a working, persisted light/dark theme toggle.

## Notable fixes found along the way

- `extract_case_id` matched any word starting with `TC` (`TCP`, `BTC-100`) — tightened to require a separator + boundary.
- Delete ✕ was invisible (unsized raw SVG) — rendered via `<Icon>`.
- Theme toggle was unreachable in the standalone app and not persisted.

## Testing

- **578 backend unit tests** (green), plus a **skip-gated live integration test** (`test_gitlab_e2e_integration.py`) that drives the real sync → CI → push loop against a running GitLab CE.
- Verified end-to-end against a live GitLab CE + runner: sync → schede `pending`, Run CI → schede flip to the real status with no duplicates, push → commit on git with a working 409 conflict guard, pipelines page shows the run.

## Migrations

- `7b2e1c4a9d10` — adds `pipelines.url` (link to the run on the provider). No data migration.

## Docs

- README: two-way + GitLab, CI status link, pipelines page, refreshed counts.
- New `docs/gitlab-ci.md` mirroring the GitHub Actions guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)