### PR TITLE
AI assistant: tag filter, structured edge cases, multi-surface access, and provider fixes

### DIFF
--- a/backend/routers/ai.py
+++ b/backend/routers/ai.py
@@ -181,7 +181,12 @@ _GENERATE_SYSTEM = (
 _SUGGEST_SYSTEM = (
     "You are a test coverage analyst. Given a list of existing test cases with their steps, "
     "identify missing edge cases that should be tested. "
-    "Return ONLY valid JSON: {\"suggestions\": [{\"title\": \"...\", \"rationale\": \"...\"}]}. "
+    "Return ONLY valid JSON: {\"suggestions\": [{\"title\": \"...\", \"rationale\": \"...\", \"category\": \"...\"}]}. "
+    "Each suggestion MUST have all three fields. "
+    "\"title\": an imperative test name, at most 8 words, consistent style. "
+    "\"rationale\": ONE short sentence on why it's a gap. "
+    "\"category\": a single lowercase word from: validation, boundary, security, "
+    "error-handling, permissions, concurrency, data-integrity, ui-state. "
     "No markdown, no other text."
 )
 

--- a/backend/routers/ai.py
+++ b/backend/routers/ai.py
@@ -106,7 +106,9 @@ async def _call_anthropic(system: str, user: str, max_tokens: int) -> str:
         )
         # Newer models can return thinking blocks before the text block, so grab
         # the first block that actually carries text rather than content[0].
-        return next((b.text for b in msg.content if getattr(b, "type", None) == "text"), "")
+        # Thinking/redacted/tool-use blocks have no string `.text`, so this skips
+        # them without depending on the block's `.type`.
+        return next((b.text for b in msg.content if isinstance(getattr(b, "text", None), str)), "")
     except anthropic_lib.RateLimitError:
         raise HTTPException(status_code=503, detail="AI service temporarily unavailable (upstream rate limit). Try again in a moment.")
     except anthropic_lib.AuthenticationError:

--- a/backend/routers/ai.py
+++ b/backend/routers/ai.py
@@ -85,6 +85,16 @@ async def _check_rate(user_id: int) -> None:
         dq.append(now)
 
 
+def _upstream_message(e: Exception) -> str:
+    """Best-effort short, human-readable reason from an SDK API error."""
+    body = getattr(e, "body", None)
+    if isinstance(body, dict):
+        err = body.get("error")
+        if isinstance(err, dict) and err.get("message"):
+            return str(err["message"])
+    return str(getattr(e, "message", None) or e)[:200]
+
+
 async def _call_anthropic(system: str, user: str, max_tokens: int) -> str:
     client = _get_client()
     try:
@@ -94,13 +104,19 @@ async def _call_anthropic(system: str, user: str, max_tokens: int) -> str:
             system=system,
             messages=[{"role": "user", "content": user}],
         )
-        return msg.content[0].text
+        # Newer models can return thinking blocks before the text block, so grab
+        # the first block that actually carries text rather than content[0].
+        return next((b.text for b in msg.content if getattr(b, "type", None) == "text"), "")
     except anthropic_lib.RateLimitError:
         raise HTTPException(status_code=503, detail="AI service temporarily unavailable (upstream rate limit). Try again in a moment.")
     except anthropic_lib.AuthenticationError:
         raise HTTPException(status_code=503, detail="AI features misconfigured (invalid API key)")
     except anthropic_lib.APIConnectionError:
         raise HTTPException(status_code=503, detail="Could not reach AI service")
+    except anthropic_lib.APIStatusError as e:
+        # Any other non-2xx (bad request / insufficient credit, unknown model,
+        # 404, 5xx, ...) — otherwise these bubble up as an opaque 500.
+        raise HTTPException(status_code=503, detail=f"AI service unavailable (upstream rejected request: {_upstream_message(e)})")
 
 
 async def _call_openai(system: str, user: str, max_tokens: int) -> str:
@@ -122,6 +138,8 @@ async def _call_openai(system: str, user: str, max_tokens: int) -> str:
         raise HTTPException(status_code=503, detail="AI features misconfigured (invalid API key)")
     except openai_lib.APIConnectionError:
         raise HTTPException(status_code=503, detail="Could not reach AI service")
+    except openai_lib.APIStatusError as e:
+        raise HTTPException(status_code=503, detail=f"AI service unavailable (upstream rejected request: {_upstream_message(e)})")
 
 
 async def _call_json(system: str, user: str, max_tokens: int = 2048) -> dict:

--- a/backend/routers/tests.py
+++ b/backend/routers/tests.py
@@ -3,7 +3,7 @@ import csv
 import io
 import uuid
 from fastapi import APIRouter, Depends, HTTPException, Response
-from sqlalchemy import or_
+from sqlalchemy import or_, cast, String
 from sqlalchemy.orm import Session
 from typing import List, Optional
 from ..db import get_db
@@ -33,6 +33,7 @@ def list_tests(
     search: Optional[str] = None,
     status: Optional[str] = None,
     type: Optional[str] = None,
+    tag: Optional[str] = None,
     limit: int = MAX_LIMIT,
     offset: int = 0,
     db: Session = Depends(get_db),
@@ -43,11 +44,19 @@ def list_tests(
         child_ids = [c.id for c in db.query(models.Folder).filter(models.Folder.parent_id == folder_id).all()]
         q = q.filter(models.Test.folder_id.in_([folder_id] + child_ids))
     if search:
-        q = q.filter(or_(models.Test.title.ilike(f"%{search}%"), models.Test.id.ilike(f"%{search}%")))
+        q = q.filter(or_(
+            models.Test.title.ilike(f"%{search}%"),
+            models.Test.id.ilike(f"%{search}%"),
+            cast(models.Test.tags, String).ilike(f"%{search}%"),
+        ))
     if status and status != "all":
         q = q.filter(models.Test.status == status)
     if type and type != "all":
         q = q.filter(models.Test.type == type)
+    if tag and tag != "all":
+        # tags stored as a JSON string list, e.g. ["ai-draft","smoke"] — match the
+        # quoted token so "ai" doesn't hit "ai-draft".
+        q = q.filter(cast(models.Test.tags, String).ilike(f'%"{tag}"%'))
     return paginate(q.order_by(models.Test.id), response, limit, offset)
 
 

--- a/e2e/suite-p4-ai-assistant/ai-assistant.spec.ts
+++ b/e2e/suite-p4-ai-assistant/ai-assistant.spec.ts
@@ -252,20 +252,20 @@ test.describe('Suite P4 — AI Assistant', () => {
     expect(suggestionsRendered).toBe(true);
   });
 
-  // SC4 — Analyze Flaky: visible only on tests with ≥1 failed run
-  test('AI-04c (SC4): Analyze Flaky button visible only when test has failed runs', async ({ page }) => {
+  // SC4 — Analyze Flaky: visible only on tests with ≥2 runs (variability needed)
+  test('AI-04c (SC4): Analyze Flaky button visible only when test has at least two runs', async ({ page }) => {
     await page.route('**/api/ai/analyze-flaky', async route => {
       await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(MOCK_ANALYZE) });
     });
 
-    // TC-1045 has 2 failed RunCases → button visible
+    // TC-1045 has 2 RunCases → button visible
     await page.goto('/#/tests/TC-1045');
     await page.waitForURL('**/#/tests/TC-1045', { timeout: 10000 });
     await page.click('.tab:has-text("Run history")');
     await page.waitForTimeout(800);
     await expect(page.locator('button:has-text("Analyze flaky")')).toBeVisible({ timeout: 5000 });
 
-    // TC-2401 has only a passing RunCase → button NOT visible
+    // TC-2401 has a single RunCase → button NOT visible
     await page.goto('/#/tests/TC-2401');
     await page.waitForURL('**/#/tests/TC-2401', { timeout: 10000 });
     await page.click('.tab:has-text("Run history")');

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -628,6 +628,7 @@ a { color: inherit; text-decoration: none; }
 .toolbar {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 6px;
   padding: 8px 22px;
   border-bottom: 1px solid var(--border);

--- a/frontend/views/view-library.jsx
+++ b/frontend/views/view-library.jsx
@@ -8,8 +8,10 @@ function Library({ onNav, onOpenTest, currentUser }) {
   const [favoritedIds, setFavoritedIds] = useState(new Set());
   const [filterStatus, setFilterStatus] = useState("all");
   const [filterType, setFilterType] = useState("all");
+  const [filterTag, setFilterTag] = useState("all");
   const [filterStatusOpen, setFilterStatusOpen] = useState(false);
   const [filterTypeOpen, setFilterTypeOpen] = useState(false);
+  const [filterTagOpen, setFilterTagOpen] = useState(false);
   const [search, setSearch] = useState("");
   const [debouncedSearch, setDebouncedSearch] = useState("");
   const [tests, setTests] = useState(null);
@@ -54,6 +56,7 @@ function Library({ onNav, onOpenTest, currentUser }) {
     if (debouncedSearch) params.set("search", debouncedSearch);
     if (filterStatus !== "all") params.set("status", filterStatus);
     if (filterType !== "all") params.set("type", filterType);
+    if (filterTag !== "all") params.set("tag", filterTag);
     setTestsLoading(true);
     fetch(`/api/tests?${params}`, { headers: window.authHeaders() })
       .then(r => r.json())
@@ -62,7 +65,7 @@ function Library({ onNav, onOpenTest, currentUser }) {
         setTestsLoading(false);
       })
       .catch(() => setTestsLoading(false));
-  }, [activeFolder, debouncedSearch, filterStatus, filterType, refreshKey]);
+  }, [activeFolder, debouncedSearch, filterStatus, filterType, filterTag, refreshKey]);
 
   const selectFolder = (id) => {
     window.__currentFolderId = id;  // expose for AIAssistant cross-view navigation
@@ -79,6 +82,12 @@ function Library({ onNav, onOpenTest, currentUser }) {
       if (f.children) f.children.forEach(c => result.push(c.id));
     });
     return result;
+  }, [D]);
+
+  const allTags = useMemo(() => {
+    const s = new Set();
+    (D?.tests || []).forEach(t => (t.tags || []).forEach(tg => s.add(tg)));
+    return [...s].sort();
   }, [D]);
 
   const filtered = tests ?? [];
@@ -267,6 +276,26 @@ function Library({ onNav, onOpenTest, currentUser }) {
                       {label}
                     </div>
                   ))}
+                </div>
+              </>
+            )}
+          </div>
+
+          <div style={{position:"relative"}}>
+            <div className={"chip" + (filterTag !== "all" ? " active" : "")} onClick={() => { setFilterTagOpen(o => !o); setFilterStatusOpen(false); setFilterTypeOpen(false); }}>
+              Tag: <b style={{color:"var(--text)", marginLeft:2}}>{filterTag}</b>
+            </div>
+            {filterTagOpen && (
+              <>
+                <div style={{position:"fixed", inset:0, zIndex:99}} onClick={() => setFilterTagOpen(false)} />
+                <div style={{position:"absolute", top:"100%", right:0, zIndex:100, background:"var(--bg-2)", border:"1px solid var(--border)", borderRadius:"var(--radius)", minWidth:130, maxHeight:280, overflowY:"auto", marginTop:4, boxShadow:"0 4px 12px rgba(0,0,0,0.3)"}}>
+                  {["all", ...allTags].map(tg => (
+                    <div key={tg} style={{padding:"7px 12px", cursor:"pointer", background: tg === filterTag ? "var(--accent-soft)" : "transparent", fontSize:12}}
+                      onClick={() => { setFilterTag(tg); setFilterTagOpen(false); }}>
+                      {tg === "all" ? "All tags" : tg}
+                    </div>
+                  ))}
+                  {allTags.length === 0 && <div style={{padding:"7px 12px", fontSize:12, color:"var(--text-muted)"}}>No tags yet</div>}
                 </div>
               </>
             )}

--- a/frontend/views/view-library.jsx
+++ b/frontend/views/view-library.jsx
@@ -24,6 +24,7 @@ function Library({ onNav, onOpenTest, currentUser }) {
   const [bulkStatusOpen, setBulkStatusOpen] = useState(false);
   const [bulkFolderOpen, setBulkFolderOpen] = useState(false);
   const [exportingCSV, setExportingCSV] = useState(false);
+  const [aiOpen, setAiOpen] = useState(false);
 
   const refresh = () => { setRefreshKey(k => k + 1); setSelected(new Set()); };
 
@@ -303,6 +304,11 @@ function Library({ onNav, onOpenTest, currentUser }) {
 
           <div className="chip">Owner: <b style={{color:"var(--text)", marginLeft:2}}>any</b></div>
 
+          <button className="btn sm" style={{marginLeft:8, background:"var(--purple)", borderColor:"var(--purple)", color:"oklch(0.16 0 0)", display:"flex", alignItems:"center", gap:5}}
+            onClick={() => setAiOpen(true)} title={activeFolder ? "Suggest edge cases for this folder" : "Suggest edge cases (pick a folder)"}>
+            <Icon name="sparkle" /> AI
+          </button>
+
           <div style={{display:"flex", border:"1px solid var(--border)", borderRadius:"var(--radius)", overflow:"hidden", marginLeft:8}}>
             <button className={"btn ghost icon"} style={{background: view==="list" ? "var(--surface-2)" : "transparent", borderRadius:0}} onClick={() => setView("list")}><Icon name="list" /></button>
             <button className={"btn ghost icon"} style={{background: view==="grid" ? "var(--surface-2)" : "transparent", borderRadius:0, borderLeft:"1px solid var(--border)"}} onClick={() => setView("grid")}><Icon name="grid" /></button>
@@ -470,6 +476,20 @@ function Library({ onNav, onOpenTest, currentUser }) {
           onClose={() => setShowNewTest(false)}
           onCreate={refresh}
         />
+      )}
+
+      {/* AI assistant drawer — scoped to the active folder (falls back to a
+          picker when viewing "All tests"). Refresh on close so new drafts show. */}
+      {aiOpen && (
+        <>
+          <div style={{position:"fixed", inset:0, background:"rgba(0,0,0,0.4)", zIndex:200}}
+            onClick={() => { setAiOpen(false); refresh(); }} />
+          <div style={{position:"fixed", top:0, right:0, bottom:0, width:400, maxWidth:"92vw", zIndex:201,
+            background:"var(--bg-2)", borderLeft:"1px solid var(--border)", padding:16, overflowY:"auto",
+            boxShadow:"-8px 0 24px rgba(0,0,0,0.3)"}}>
+            <AiSuggestBox D={D} folderId={activeFolder || undefined} onClose={() => { setAiOpen(false); refresh(); }} />
+          </div>
+        </>
       )}
 
       {/* Delete single confirm */}

--- a/frontend/views/view-overview.jsx
+++ b/frontend/views/view-overview.jsx
@@ -186,7 +186,7 @@ function Overview({ onNav, currentUser }) {
 
 // Compact AI coverage widget — analyzes a folder's tests via /api/ai/suggest-edge-cases
 // and can create pending draft tests from the suggestions.
-function AiSuggestBox({ D }) {
+function AiSuggestBox({ D, folderId: fixedFolderId, onClose }) {
   // Map every folder id → leaf name and → full ancestor path across the whole
   // tree (any depth). Imported folders nest several levels deep and reuse leaf
   // names (many "extra.spec.ts"), so the picker shows the full path to
@@ -210,7 +210,10 @@ function AiSuggestBox({ D }) {
   const folderIds = [...new Set(D.tests.map(t => t.folder).filter(Boolean))]
     .sort((a, b) => (folderPaths[a] || a).localeCompare(folderPaths[b] || b));
 
-  const [folderId, setFolderId] = React.useState(folderIds[0] || "");
+  // When a folder is forced (launched from Library on the active folder) the
+  // picker is hidden and we lock onto it.
+  const [folderId, setFolderId] = React.useState(fixedFolderId || folderIds[0] || "");
+  React.useEffect(() => { if (fixedFolderId) setFolderId(fixedFolderId); }, [fixedFolderId]);
   const [loading, setLoading] = React.useState(false);
   const [err, setErr] = React.useState(null);
   const [result, setResult] = React.useState(null);
@@ -261,18 +264,28 @@ function AiSuggestBox({ D }) {
     <div className="ai-box">
       <div style={{display:"flex", alignItems:"center", gap:8, marginBottom:10}}>
         <span style={{fontSize:11, fontFamily:"var(--font-mono)", textTransform:"uppercase", letterSpacing:"0.08em", color:"var(--purple)"}}>AI assistant</span>
+        {onClose && <button className="btn ghost icon sm" style={{marginLeft:"auto"}} onClick={onClose} aria-label="Close"><Icon name="x" /></button>}
       </div>
 
       {!result && (
         <>
           <div style={{fontSize:13, fontWeight:500, marginBottom:6}}>Find missing edge cases</div>
           <div style={{fontSize:12, color:"var(--text-muted)", lineHeight:1.5, marginBottom:10}}>
-            Pick a folder — AI compares its existing tests and suggests uncovered edge cases.
+            {fixedFolderId
+              ? "AI compares this folder's existing tests and suggests uncovered edge cases."
+              : "Pick a folder — AI compares its existing tests and suggests uncovered edge cases."}
           </div>
           <div style={{display:"flex", gap:6, alignItems:"center"}}>
-            <select className="input" style={{flex:1, minWidth:0}} value={folderId} onChange={e => setFolderId(e.target.value)} disabled={loading}>
-              {folderIds.map(id => <option key={id} value={id}>{(folderPaths[id] || folderNames[id] || id) + ` (${folderCounts[id] || 0})`}</option>)}
-            </select>
+            {fixedFolderId ? (
+              <div className="input" style={{flex:1, minWidth:0, display:"flex", alignItems:"center", overflow:"hidden", textOverflow:"ellipsis", whiteSpace:"nowrap"}}
+                title={folderPaths[folderId] || folderNames[folderId] || folderId}>
+                {(folderPaths[folderId] || folderNames[folderId] || folderId) + ` (${folderCounts[folderId] || 0})`}
+              </div>
+            ) : (
+              <select className="input" style={{flex:1, minWidth:0}} value={folderId} onChange={e => setFolderId(e.target.value)} disabled={loading}>
+                {folderIds.map(id => <option key={id} value={id}>{(folderPaths[id] || folderNames[id] || id) + ` (${folderCounts[id] || 0})`}</option>)}
+              </select>
+            )}
             <button className="btn sm" style={{background:"var(--purple)", borderColor:"var(--purple)", color:"oklch(0.16 0 0)"}}
               onClick={analyze} disabled={loading || !folderId}>
               {loading ? "Analyzing…" : "Analyze"}
@@ -487,3 +500,4 @@ window.StatusSelect = StatusSelect;
 window.ProgressBar = ProgressBar;
 window.Metric = Metric;
 window.timeAgo = timeAgo;
+window.AiSuggestBox = AiSuggestBox;

--- a/frontend/views/view-overview.jsx
+++ b/frontend/views/view-overview.jsx
@@ -218,7 +218,7 @@ function AiSuggestBox({ D }) {
     let n = 0;
     try {
       for (const s of result.suggestions) {
-        await TH_API.createTest({ title: s.title, folder_id: folderId, status: "pending" });
+        await TH_API.createTest({ title: s.title, folder_id: folderId, status: "pending", tags: ["ai-draft"] });
         n++;
       }
       setCreatedCount(n);

--- a/frontend/views/view-overview.jsx
+++ b/frontend/views/view-overview.jsx
@@ -187,16 +187,28 @@ function Overview({ onNav, currentUser }) {
 // Compact AI coverage widget — analyzes a folder's tests via /api/ai/suggest-edge-cases
 // and can create pending draft tests from the suggestions.
 function AiSuggestBox({ D }) {
-  // Map every folder id → name across the whole tree (any depth). Imported
-  // folders nest several levels deep, so a shallow walk left leaf ids showing
-  // as raw "F-…" in the picker.
+  // Map every folder id → leaf name and → full ancestor path across the whole
+  // tree (any depth). Imported folders nest several levels deep and reuse leaf
+  // names (many "extra.spec.ts"), so the picker shows the full path to
+  // disambiguate.
   const folderNames = {};
-  const walkFolders = (list) => (list || []).forEach(f => {
+  const folderPaths = {};
+  const walkFolders = (list, prefix) => (list || []).forEach(f => {
+    const path = prefix ? `${prefix} ‹ ${f.name}` : f.name;
     folderNames[f.id] = f.name;
-    walkFolders(f.children);
+    folderPaths[f.id] = path;
+    walkFolders(f.children, path);
   });
-  walkFolders(D.folders);
-  const folderIds = [...new Set(D.tests.map(t => t.folder).filter(Boolean))];
+  walkFolders(D.folders, "");
+
+  // Direct test count per folder — matches what the analysis reads (exact
+  // folder, no subfolders), so the number reflects what will be sent.
+  const folderCounts = {};
+  D.tests.forEach(t => { if (t.folder) folderCounts[t.folder] = (folderCounts[t.folder] || 0) + 1; });
+
+  // Only folders that actually have tests, sorted alphabetically by path.
+  const folderIds = [...new Set(D.tests.map(t => t.folder).filter(Boolean))]
+    .sort((a, b) => (folderPaths[a] || a).localeCompare(folderPaths[b] || b));
 
   const [folderId, setFolderId] = React.useState(folderIds[0] || "");
   const [loading, setLoading] = React.useState(false);
@@ -204,20 +216,33 @@ function AiSuggestBox({ D }) {
   const [result, setResult] = React.useState(null);
   const [creating, setCreating] = React.useState(false);
   const [createdCount, setCreatedCount] = React.useState(0);
+  const [selected, setSelected] = React.useState(new Set());
 
   const analyze = () => {
-    setLoading(true); setErr(null); setResult(null); setCreatedCount(0);
+    setLoading(true); setErr(null); setResult(null); setCreatedCount(0); setSelected(new Set());
     TH_API.suggestEdgeCases({ folder_id: folderId })
-      .then(data => { setResult(data); setLoading(false); })
+      .then(data => {
+        setResult(data);
+        // pre-select every suggestion; user unticks the ones they don't want
+        setSelected(new Set((data?.suggestions || []).map((_, i) => i)));
+        setLoading(false);
+      })
       .catch(e => { setErr(e.message); setLoading(false); });
   };
 
+  const toggle = (i) => setSelected(s => {
+    const n = new Set(s);
+    n.has(i) ? n.delete(i) : n.add(i);
+    return n;
+  });
+
   const generateDrafts = async () => {
-    if (!result?.suggestions?.length) return;
+    const picks = (result?.suggestions || []).filter((_, i) => selected.has(i));
+    if (!picks.length) return;
     setCreating(true); setErr(null);
     let n = 0;
     try {
-      for (const s of result.suggestions) {
+      for (const s of picks) {
         await TH_API.createTest({ title: s.title, folder_id: folderId, status: "pending", tags: ["ai-draft"] });
         n++;
       }
@@ -246,7 +271,7 @@ function AiSuggestBox({ D }) {
           </div>
           <div style={{display:"flex", gap:6, alignItems:"center"}}>
             <select className="input" style={{flex:1, minWidth:0}} value={folderId} onChange={e => setFolderId(e.target.value)} disabled={loading}>
-              {folderIds.map(id => <option key={id} value={id}>{folderNames[id] || id}</option>)}
+              {folderIds.map(id => <option key={id} value={id}>{(folderPaths[id] || folderNames[id] || id) + ` (${folderCounts[id] || 0})`}</option>)}
             </select>
             <button className="btn sm" style={{background:"var(--purple)", borderColor:"var(--purple)", color:"oklch(0.16 0 0)"}}
               onClick={analyze} disabled={loading || !folderId}>
@@ -264,16 +289,30 @@ function AiSuggestBox({ D }) {
           {suggestions.length === 0 && (
             <div style={{fontSize:12, color:"var(--text-muted)", lineHeight:1.5}}>No gaps found — coverage looks solid.</div>
           )}
-          <ul style={{margin:"10px 0 12px", padding:"0 0 0 18px", fontSize:12, color:"var(--text-muted)", lineHeight:1.7}}>
-            {suggestions.map((s, i) => (
-              <li key={i}><span style={{color:"var(--text)"}}>{s.title}</span>{s.rationale ? ` — ${s.rationale}` : ""}</li>
-            ))}
-          </ul>
+          <div style={{margin:"10px 0 12px", display:"flex", flexDirection:"column", gap:6}}>
+            {suggestions.map((s, i) => {
+              const on = selected.has(i);
+              return (
+                <label key={i} style={{display:"flex", gap:8, alignItems:"flex-start", padding:"8px 10px", cursor:"pointer",
+                  border:"1px solid var(--border)", borderRadius:"var(--radius)",
+                  background: on ? "var(--accent-soft)" : "transparent", opacity: createdCount > 0 ? 0.6 : 1}}>
+                  <input type="checkbox" checked={on} disabled={createdCount > 0} onChange={() => toggle(i)} style={{marginTop:2}} />
+                  <div style={{minWidth:0, flex:1}}>
+                    <div style={{display:"flex", gap:6, alignItems:"center", flexWrap:"wrap"}}>
+                      <span style={{fontSize:12.5, fontWeight:500, color:"var(--text)"}}>{s.title}</span>
+                      {s.category && <span className="tag" style={{fontSize:10, textTransform:"uppercase", letterSpacing:"0.04em"}}>{s.category}</span>}
+                    </div>
+                    {s.rationale && <div style={{fontSize:11.5, color:"var(--text-muted)", lineHeight:1.5, marginTop:2}}>{s.rationale}</div>}
+                  </div>
+                </label>
+              );
+            })}
+          </div>
           <div style={{display:"flex", gap:6}}>
             {suggestions.length > 0 && createdCount === 0 && (
               <button className="btn sm" style={{background:"var(--purple)", borderColor:"var(--purple)", color:"oklch(0.16 0 0)"}}
-                onClick={generateDrafts} disabled={creating}>
-                {creating ? "Creating…" : "Generate drafts"}
+                onClick={generateDrafts} disabled={creating || selected.size === 0}>
+                {creating ? "Creating…" : `Create ${selected.size} selected`}
               </button>
             )}
             {createdCount > 0 && (

--- a/frontend/views/view-test-detail.jsx
+++ b/frontend/views/view-test-detail.jsx
@@ -448,7 +448,8 @@ function HistoryTab({test}) {
 
   return (
     <div style={{padding:"18px 22px 32px"}}>
-      {rows.some(r => r.case_status === "fail") && (
+      {/* Needs at least two runs to reason about variability, regardless of outcome. */}
+      {rows.length >= 2 && (
         <div className="card" style={{marginBottom:14, borderColor:"var(--purple)"}}>
           <div className="card-h">
             <div className="card-title">AI Flaky Analysis</div>


### PR DESCRIPTION
## Summary

Makes the AI assistant usable and discoverable end-to-end, and fixes two bugs found while testing the Anthropic provider live.

## Changes

- **Tag filter in Library** — new `tag` query param on `/tests` (quoted-token match on the JSON tags list) plus a "Tag" filter chip; free-text search now also covers tags.
- **AI drafts tagged `ai-draft`** — edge-case drafts are tagged so they're distinguishable from imported/manual pending tests.
- **Structured edge-case suggestions** — the prompt now requires `title` + `rationale` + `category` (fixed set) on every item; the widget renders selectable cards (checkbox + category chip) and creates only the checked drafts. Folder picker shows the full ancestor path + direct test count.
- **Launch the assistant from the test list** — a ✨ AI button opens the edge-case assistant in a side drawer scoped to the active folder. `AiSuggestBox` is reused (optional fixed `folderId` + `onClose`, exported as `window.AiSuggestBox`).
- **Flaky analysis on more tests** — the "AI Flaky Analysis" card now shows on any test with ≥2 runs (was ≥1 failed run); flakiness needs variability, not a fail.

## Fixes

- **ThinkingBlock crash** — reading `msg.content[0].text` crashed (`AttributeError`) on models that emit a thinking block first (e.g. Sonnet 5). Now pick the first `type == "text"` block.
- **Opaque 500s** — any non-2xx from the provider (insufficient credit, unknown model, upstream 5xx) bubbled up as a 500. Both providers now catch the SDK `APIStatusError` and return a 503 with the upstream message.

## Testing

- `suite-p4-ai-assistant` e2e green (9 passed), including AI-04c updated to the ≥2-runs gating.
- Manual end-to-end against a live Ollama and a live Anthropic Sonnet 5 provider (generate-tests, suggest-edge-cases, analyze-flaky).

🤖 Generated with [Claude Code](https://claude.com/claude-code)