### PR TITLE
feat(pipelines): expandable CI rows, self-healing reconcile, Test health fix

### DIFF
--- a/backend/importers/persist.py
+++ b/backend/importers/persist.py
@@ -22,7 +22,7 @@ def persist_import_result(db, result: ImportResult, provider: str, conflict: str
     plain results file shouldn't silently rewrite test statuses; the CI
     collectors opt in so a pipeline result is the source of truth for status."""
     now = datetime.now(timezone.utc).isoformat()
-    stats = {"folders": 0, "tests": 0, "runs": 0, "defects": 0, "skipped": 0}
+    stats = {"folders": 0, "tests": 0, "runs": 0, "defects": 0, "skipped": 0, "run_ids": []}
 
     # ── Folders ────────────────────────────────────────────────
     folder_cache: dict[str, str] = {}  # path → folder.id
@@ -194,6 +194,7 @@ def persist_import_result(db, result: ImportResult, provider: str, conflict: str
                     linked.last_run_at = now
 
         stats["runs"] += 1
+        stats["run_ids"].append(rid)
 
     # ── Defects ───────────────────────────────────────────────
     for d in result.defects:

--- a/backend/importers/persist.py
+++ b/backend/importers/persist.py
@@ -177,6 +177,7 @@ def persist_import_result(db, result: ImportResult, provider: str, conflict: str
             blocked=blocked,
             progress=100 if total > 0 else 0,
             started=now,
+            created_at=now,   # so CI/file-imported runs show up in Test health (bucketed by date)
             source_run_id=run_data.source_id or None,
         )
         db.add(run)

--- a/backend/models.py
+++ b/backend/models.py
@@ -146,6 +146,8 @@ class Pipeline(Base):
     branch = Column(String(255), nullable=True)
     when = Column(String(64), nullable=True)
     url = Column(String(512), nullable=True)   # link to the run on GitHub/GitLab
+    run_id = Column(String(255), ForeignKey("runs.id"), nullable=True)  # imported Run holding this pipeline's test cases (for row expand)
+    integration_id = Column(String(255), nullable=True)  # source integration — lets a reconcile poll re-query the provider after a restart
 
 
 class TestPlan(Base):

--- a/backend/routers/ci.py
+++ b/backend/routers/ci.py
@@ -14,7 +14,7 @@ from pydantic import BaseModel
 
 from ..db import get_db, SessionLocal
 from .. import models
-from ..auth_utils import require_role
+from ..auth_utils import require_role, get_current_user
 from ..github_actions import (
     GitHubActionsClient, ci_config, pick_dispatched_run, collect_run_results,
 )
@@ -23,6 +23,7 @@ from ..gitlab_actions import (
     _TERMINAL as GITLAB_TERMINAL,
 )
 from ..vcs import detect_provider
+from ..schemas import PipelineOut
 
 logger = logging.getLogger("thorotest.ci")
 router = APIRouter(tags=["ci"])
@@ -133,6 +134,7 @@ def _orchestrate(job_id: str, cfg: dict, since: datetime, run_name: Optional[str
                     author=(run.get("actor") or {}).get("login"),
                     when="just now",
                     url=run.get("html_url"),
+                    integration_id=cfg.get("integration_id"),
                 )
             finally:
                 db0.close()
@@ -161,6 +163,7 @@ def _orchestrate(job_id: str, cfg: dict, since: datetime, run_name: Optional[str
                     db, pipeline_row_id,
                     status="pass" if concl == "success" else "fail",
                     duration=_fmt_duration(_gh_run_seconds(detail)),
+                    run_id=(stats.get("run_ids") or [None])[-1],
                 )
             finally:
                 db.close()
@@ -207,6 +210,7 @@ def _orchestrate_gitlab(job_id: str, cfg: dict, run_name: Optional[str]) -> None
                         db, pid,
                         status="pass" if concl == "success" else "fail",
                         duration=_fmt_duration(detail.get("duration")),
+                        run_id=(stats.get("run_ids") or [None])[-1],
                     )
             finally:
                 db.close()
@@ -251,6 +255,7 @@ async def ci_run(intg_id: str, payload: CIRunRequest, db: Session = Depends(get_
             commit=(pipeline.get("sha") or "")[:7] or None,
             branch=pipeline.get("ref") or cfg["ref"], when="just now",
             url=pipeline.get("web_url"),
+            integration_id=intg_id,
         )
         _JOBS[job_id] = {
             "id": job_id,
@@ -270,6 +275,7 @@ async def ci_run(intg_id: str, payload: CIRunRequest, db: Session = Depends(get_
         cfg = _resolve_cfg(intg, payload)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=f"Not a GitHub integration: {e}")
+    cfg["integration_id"] = intg_id
 
     since = datetime.now(timezone.utc)
     try:
@@ -297,3 +303,81 @@ def ci_job_status(intg_id: str, job_id: str, _: models.User = WRITE_ROLES):
     if not job or job.get("integration_id") != intg_id:
         raise HTTPException(status_code=404, detail="Job not found")
     return job
+
+
+# ── Reconcile stuck 'running' rows against the provider ─────────
+# The dispatch orchestrator polls in an in-memory worker thread, so a row can be
+# left stuck on 'running' if that thread dies or the process restarts. This
+# re-queries the provider for the real status of any 'running' pipeline (keyed by
+# the run id encoded in the row id + the stored integration), imports results
+# when it finds one finished, and flips the row to pass/fail. Idempotent.
+
+def _reconcile_github(db, pipe, intg) -> bool:
+    run_id = pipe.id[len("gh-run-"):]
+    if not run_id.isdigit():
+        return False
+    cfg = ci_config(intg)
+    with GitHubActionsClient(cfg["token"]) as client:
+        detail = client.get_run(cfg["owner"], cfg["repo"], int(run_id))
+        if detail.get("status") != "completed":
+            return False   # genuinely still running — leave it
+        stats = collect_run_results(
+            db, client, cfg["owner"], cfg["repo"], int(run_id), cfg["artifact"], pipe.name,
+        )
+        _upsert_pipeline(
+            db, pipe.id,
+            status="pass" if detail.get("conclusion") == "success" else "fail",
+            duration=_fmt_duration(_gh_run_seconds(detail)),
+            run_id=(stats.get("run_ids") or [None])[-1],
+        )
+    return True
+
+
+def _reconcile_gitlab(db, pipe, intg) -> bool:
+    pid = pipe.id[len("gl-pipeline-"):]
+    if not pid.isdigit():
+        return False
+    cfg = gitlab_ci_config(intg)
+    with GitLabActionsClient(cfg["api_base"], cfg["token"]) as client:
+        detail = client.get_pipeline(cfg["project"], int(pid))
+        if detail.get("status") not in GITLAB_TERMINAL:
+            return False
+        stats = collect_pipeline_results(db, client, cfg["project"], int(pid), pipe.name)
+        _upsert_pipeline(
+            db, pipe.id,
+            status="pass" if detail.get("status") == "success" else "fail",
+            duration=_fmt_duration(detail.get("duration")),
+            run_id=(stats.get("run_ids") or [None])[-1],
+        )
+    return True
+
+
+def reconcile_running_pipelines(db) -> int:
+    """Re-query the provider for every 'running' pipeline and finalize the ones
+    that have actually finished. Returns the count updated."""
+    running = db.query(models.Pipeline).filter(models.Pipeline.status == "running").all()
+    updated = 0
+    for pipe in running:
+        if not pipe.integration_id:
+            continue   # pushed via API without a source integration — can't re-query
+        intg = db.query(models.Integration).filter(models.Integration.id == pipe.integration_id).first()
+        if not intg:
+            continue
+        try:
+            if pipe.platform == "github" and pipe.id.startswith("gh-run-"):
+                updated += _reconcile_github(db, pipe, intg)
+            elif pipe.platform == "gitlab" and pipe.id.startswith("gl-pipeline-"):
+                updated += _reconcile_gitlab(db, pipe, intg)
+        except Exception as e:
+            logger.warning("reconcile of pipeline %s failed: %s", pipe.id, e)
+    return updated
+
+
+@router.post("/pipelines/reconcile")
+def pipelines_reconcile(db: Session = Depends(get_db), _: models.User = Depends(get_current_user)):
+    """Poll the provider for any stuck 'running' pipelines and finalize them.
+    Called by the pipelines page's live poll so rows self-heal. Returns the
+    fresh pipeline list so the client can refresh in one round-trip."""
+    updated = reconcile_running_pipelines(db)
+    pipes = db.query(models.Pipeline).order_by(models.Pipeline.id).all()
+    return {"updated": updated, "pipelines": [PipelineOut.model_validate(p) for p in pipes]}

--- a/backend/routers/pipelines.py
+++ b/backend/routers/pipelines.py
@@ -2,9 +2,10 @@ import uuid
 from fastapi import APIRouter, Depends, HTTPException, Response
 from sqlalchemy.orm import Session
 from typing import List
+from sqlalchemy.orm import joinedload
 from ..db import get_db
 from .. import models
-from ..schemas import PipelineOut, PipelineCreate
+from ..schemas import PipelineOut, PipelineCreate, RunCaseOut
 from ..auth_utils import get_current_user, require_role
 from ._pagination import paginate, MAX_LIMIT
 
@@ -22,6 +23,40 @@ def list_pipelines(
     _: models.User = Depends(get_current_user),
 ):
     return paginate(db.query(models.Pipeline).order_by(models.Pipeline.id), response, limit, offset)
+
+
+@router.get("/pipelines/{pipeline_id}/cases", response_model=List[RunCaseOut])
+def pipeline_cases(
+    pipeline_id: str,
+    db: Session = Depends(get_db),
+    _: models.User = Depends(get_current_user),
+):
+    """Individual test cases of the Run this pipeline imported — powers the
+    expandable pipeline row. Empty list if no Run is linked (e.g. a pipeline
+    pushed via the API without result import)."""
+    pipe = db.query(models.Pipeline).filter(models.Pipeline.id == pipeline_id).first()
+    if not pipe:
+        raise HTTPException(status_code=404, detail="Pipeline not found")
+    if not pipe.run_id:
+        return []
+    cases = (
+        db.query(models.RunCase)
+        .options(joinedload(models.RunCase.test))
+        .filter(models.RunCase.run_id == pipe.run_id)
+        .all()
+    )
+    return [
+        RunCaseOut(
+            id=c.id,
+            run_id=c.run_id,
+            test_id=c.test_id,
+            status=c.status,
+            title=c.test.title if c.test else c.test_id,
+            duration=(c.test.duration if c.test and c.test.duration else None),
+            assigned_to=c.assigned_to,
+        )
+        for c in cases
+    ]
 
 
 @router.post("/pipelines", response_model=PipelineOut, status_code=201)

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -168,6 +168,7 @@ class PipelineOut(BaseModel):
     branch: Optional[str] = None
     when: Optional[str] = None
     url: Optional[str] = None
+    run_id: Optional[str] = None   # set → row is expandable to the run's test cases
 
     model_config = {"from_attributes": True}
 

--- a/backend/tests/test_ci_pipeline_row.py
+++ b/backend/tests/test_ci_pipeline_row.py
@@ -96,6 +96,113 @@ def test_delete_pipeline_unknown_404(client, db):
     assert client.delete("/api/pipelines/nope").status_code == 404
 
 
+# ── pipeline row expand → run test cases ────────────────────────
+
+def test_pipeline_cases_returns_run_cases(client, db):
+    db.add(models.Test(id="TC-EXP1", title="Expand me"))
+    db.add(models.Run(id="R-EXP", name="CI run", status="fail", total=2))
+    db.add(models.Pipeline(id="wf-exp", name="ci.yml", platform="github",
+                           status="fail", run_id="R-EXP"))
+    db.add(models.RunCase(run_id="R-EXP", test_id="TC-EXP1", status="pass"))
+    db.add(models.RunCase(run_id="R-EXP", test_id="TC-EXP1", status="fail"))
+    db.commit()
+
+    r = client.get("/api/pipelines/wf-exp/cases")
+    assert r.status_code == 200, r.text
+    cases = r.json()
+    assert len(cases) == 2
+    assert {c["status"] for c in cases} == {"pass", "fail"}
+    assert cases[0]["title"] == "Expand me"       # joined test title
+    assert cases[0]["test_id"] == "TC-EXP1"
+
+
+def test_pipeline_cases_empty_when_no_run_linked(client, db):
+    db.add(models.Pipeline(id="wf-norun", name="ci.yml", platform="github", status="pass"))
+    db.commit()
+    r = client.get("/api/pipelines/wf-norun/cases")
+    assert r.status_code == 200
+    assert r.json() == []
+
+
+def test_pipeline_cases_unknown_404(client, db):
+    assert client.get("/api/pipelines/nope/cases").status_code == 404
+
+
+# ── reconcile: heal stuck 'running' rows against the provider ────
+
+class _FakeGH:
+    """Context-manager stub for GitHubActionsClient."""
+    def __init__(self, detail):
+        self._detail = detail
+    def __enter__(self): return self
+    def __exit__(self, *a): return False
+    def get_run(self, owner, repo, run_id): return self._detail
+
+
+def _gh_running_pipeline(db):
+    db.add(models.Integration(id="int-gh", name="GH", type="vcs_ci", icon="github",
+                              config={"repo_url": "https://github.com/acme/web", "token": "ghp_x"}))
+    db.add(models.Pipeline(id="gh-run-777", name="CI", platform="github",
+                           status="running", integration_id="int-gh"))
+    db.commit()
+
+
+def test_reconcile_finalizes_completed_run(client, db, monkeypatch):
+    from backend.routers import ci as ci_router
+    _gh_running_pipeline(db)
+    detail = {"status": "completed", "conclusion": "success",
+              "run_started_at": "2026-07-09T10:00:00Z", "updated_at": "2026-07-09T10:02:00Z"}
+    monkeypatch.setattr(ci_router, "ci_config",
+                        lambda intg: {"owner": "acme", "repo": "web", "token": "ghp_x", "artifact": "junit"})
+    monkeypatch.setattr(ci_router, "GitHubActionsClient", lambda token: _FakeGH(detail))
+
+    def _fake_collect(db_, client_, owner, repo, run_id, artifact, run_name):
+        db_.add(models.Run(id="R-NEW", name=run_name, status="pass", total=1))
+        db_.flush()
+        return {"run_ids": ["R-NEW"]}
+    monkeypatch.setattr(ci_router, "collect_run_results", _fake_collect)
+
+    n = ci_router.reconcile_running_pipelines(db)
+    assert n == 1
+    p = db.query(models.Pipeline).filter_by(id="gh-run-777").first()
+    assert p.status == "pass"
+    assert p.duration == "2m 00s"
+    assert p.run_id == "R-NEW"
+
+
+def test_reconcile_leaves_still_running(client, db, monkeypatch):
+    from backend.routers import ci as ci_router
+    _gh_running_pipeline(db)
+    monkeypatch.setattr(ci_router, "ci_config",
+                        lambda intg: {"owner": "acme", "repo": "web", "token": "ghp_x", "artifact": "junit"})
+    monkeypatch.setattr(ci_router, "GitHubActionsClient",
+                        lambda token: _FakeGH({"status": "in_progress"}))
+    assert ci_router.reconcile_running_pipelines(db) == 0
+    assert db.query(models.Pipeline).filter_by(id="gh-run-777").first().status == "running"
+
+
+def test_reconcile_skips_pipeline_without_integration(client, db, monkeypatch):
+    from backend.routers import ci as ci_router
+    db.add(models.Pipeline(id="gh-run-9", name="CI", platform="github", status="running"))
+    db.commit()
+
+    def _boom(*a, **k):
+        raise AssertionError("should not query provider without an integration")
+    monkeypatch.setattr(ci_router, "GitHubActionsClient", _boom)
+    assert ci_router.reconcile_running_pipelines(db) == 0
+
+
+def test_reconcile_endpoint_returns_fresh_list(client, db, monkeypatch):
+    from backend.routers import ci as ci_router
+    db.add(models.Pipeline(id="wf-static", name="ci.yml", platform="github", status="pass"))
+    db.commit()
+    r = client.post("/api/pipelines/reconcile")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert "updated" in body
+    assert any(p["id"] == "wf-static" for p in body["pipelines"])
+
+
 def test_ci_run_dispatch_failure_502(client, db, monkeypatch):
     from backend.routers import ci as ci_router
 

--- a/backend/tests/test_import_execute.py
+++ b/backend/tests/test_import_execute.py
@@ -86,6 +86,9 @@ def test_execution_links_run_case_by_source_id(client, db):
     linked = db.query(models.Test).filter(models.Test.id == rc.test_id).one()
     assert linked.external_key == "PROJ-T1"
     assert rc.status == "pass"
+    # Imported runs must carry created_at, else they're invisible to the
+    # Test health chart (which buckets runs by created_at date).
+    assert run.created_at is not None
 
 
 def test_xray_results_link_to_previously_imported_tests(client, db):

--- a/frontend/api.js
+++ b/frontend/api.js
@@ -616,6 +616,18 @@
       if (!res.ok && res.status !== 204) { const e = await res.json().catch(() => ({})); throw new Error(e.detail || "Delete failed"); }
     },
 
+    async pipelineCases(id) {
+      const res = await fetch(BASE + `/api/pipelines/${id}/cases`, { headers: authHeaders() });
+      if (!res.ok) { const e = await res.json().catch(() => ({})); throw new Error(e.detail || "Failed to load cases"); }
+      return res.json();
+    },
+
+    async reconcilePipelines() {
+      const res = await fetch(BASE + `/api/pipelines/reconcile`, { method: "POST", headers: authHeaders() });
+      if (!res.ok) { const e = await res.json().catch(() => ({})); throw new Error(e.detail || "Reconcile failed"); }
+      return res.json();   // { updated, pipelines }
+    },
+
     async syncIntegration(id) {
       const res = await fetch(BASE + `/api/integrations/${id}/sync`, { method: "POST", headers: authHeaders() });
       if (!res.ok) { const e = await res.json().catch(() => ({})); throw new Error(e.detail || "Sync failed"); }

--- a/frontend/views/view-misc.jsx
+++ b/frontend/views/view-misc.jsx
@@ -12,12 +12,17 @@ function Pipelines() {
   const anyRunning = (rows || []).some(p => p.status === "running");
   React.useEffect(() => {
     if (!anyRunning) return;
+    let inFlight = false;   // reconcile hits the CI provider — don't stack calls
     const id = setInterval(async () => {
+      if (inFlight) return;
+      inFlight = true;
       try {
-        const res = await fetch('/api/pipelines', { headers: window.authHeaders() });
-        if (res.ok) setRows(await res.json());
+        // Re-query the provider for stuck 'running' rows and refresh in one round-trip.
+        const { pipelines } = await TH_API.reconcilePipelines();
+        if (pipelines) setRows(pipelines);
       } catch {}
-    }, 4000);
+      finally { inFlight = false; }
+    }, 5000);
     return () => clearInterval(id);
   }, [anyRunning]);
 
@@ -29,6 +34,25 @@ function Pipelines() {
       setRows(rs => (rs || []).filter(p => p.id !== id));
     } catch (err) {
       window.alert(err.message);
+    }
+  }
+
+  // Row expansion → individual test cases of the imported run.
+  const [expanded, setExpanded] = React.useState(null);   // pipeline id or null
+  const [cases, setCases] = React.useState({});           // id → { loading, error, items }
+
+  async function toggleExpand(p, e) {
+    e.stopPropagation();   // don't also open the run URL
+    if (expanded === p.id) { setExpanded(null); return; }
+    setExpanded(p.id);
+    if (!cases[p.id]) {
+      setCases(c => ({ ...c, [p.id]: { loading: true } }));
+      try {
+        const items = await TH_API.pipelineCases(p.id);
+        setCases(c => ({ ...c, [p.id]: { items } }));
+      } catch (err) {
+        setCases(c => ({ ...c, [p.id]: { error: err.message } }));
+      }
     }
   }
 
@@ -86,15 +110,28 @@ function Pipelines() {
               </tr>
             </thead>
             <tbody>
-              {list.map(p => (
-                <tr key={p.id}
+              {list.map(p => {
+                const isOpen = expanded === p.id;
+                const cs = cases[p.id];
+                return (
+                <React.Fragment key={p.id}>
+                <tr
                     style={p.url ? {cursor:"pointer"} : undefined}
                     title={p.url ? "Open the run on the CI provider" : undefined}
                     onClick={p.url ? () => window.open(p.url, "_blank", "noopener,noreferrer") : undefined}>
                   <td>
-                    <span style={{display:"inline-flex", width:18, height:18}}>
-                      {p.platform === "github" ? I.github : p.platform === "gitlab" ? I.gitlab : I.jenkins}
-                    </span>
+                    {p.run_id ? (
+                      <button className="btn ghost icon sm"
+                              title={isOpen ? "Collapse" : "Show test cases"}
+                              onClick={e => toggleExpand(p, e)}
+                              style={{transform: isOpen ? "rotate(90deg)" : "none", transition:"transform .12s"}}>
+                        <Icon name="chev" />
+                      </button>
+                    ) : (
+                      <span style={{display:"inline-flex", width:18, height:18}}>
+                        {p.platform === "github" ? I.github : p.platform === "gitlab" ? I.gitlab : I.jenkins}
+                      </span>
+                    )}
                   </td>
                   <td>{p.name}{p.url && <span className="dim" style={{marginLeft:6, fontSize:11}}>↗</span>}</td>
                   <td><StatusBadge s={p.status} /></td>
@@ -111,7 +148,35 @@ function Pipelines() {
                     </button>
                   </td>
                 </tr>
-              ))}
+                {isOpen && (
+                  <tr className="pipeline-cases-row">
+                    <td></td>
+                    <td colSpan={8} style={{padding:0}}>
+                      {cs?.loading && <div className="dim" style={{padding:"8px 4px", fontSize:12}}>Loading test cases…</div>}
+                      {cs?.error && <div style={{padding:"8px 4px", fontSize:12, color:"var(--fail)"}}>{cs.error}</div>}
+                      {cs?.items && cs.items.length === 0 && (
+                        <div className="dim" style={{padding:"8px 4px", fontSize:12}}>No test cases recorded for this run.</div>
+                      )}
+                      {cs?.items && cs.items.length > 0 && (
+                        <table className="table" style={{margin:"2px 0 6px", background:"var(--bg-2)"}}>
+                          <tbody>
+                            {cs.items.map(c => (
+                              <tr key={c.id}>
+                                <td className="mono dim" style={{width:120}}>{c.test_id}</td>
+                                <td>{c.title}</td>
+                                <td style={{width:100}}><StatusBadge s={c.status} /></td>
+                                <td className="mono dim" style={{width:90}}>{c.duration || "—"}</td>
+                              </tr>
+                            ))}
+                          </tbody>
+                        </table>
+                      )}
+                    </td>
+                  </tr>
+                )}
+                </React.Fragment>
+                );
+              })}
             </tbody>
           </table>
         )}

--- a/migrations/versions/b4c8e2f1a9d3_pipeline_run_id.py
+++ b/migrations/versions/b4c8e2f1a9d3_pipeline_run_id.py
@@ -1,0 +1,26 @@
+"""pipelines.run_id — link a pipeline to the imported Run holding its test cases
+
+Revision ID: b4c8e2f1a9d3
+Revises: 07ab187d3790
+Create Date: 2026-07-14 10:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'b4c8e2f1a9d3'
+down_revision = '07ab187d3790'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column('pipelines', sa.Column('run_id', sa.String(length=255), nullable=True))
+    # No FK constraint added: SQLite can't ALTER-add one, and the app treats a
+    # dangling run_id as "no cases" anyway.
+
+
+def downgrade() -> None:
+    op.drop_column('pipelines', 'run_id')

--- a/migrations/versions/c5d9f3a2b8e1_pipeline_integration_id.py
+++ b/migrations/versions/c5d9f3a2b8e1_pipeline_integration_id.py
@@ -1,0 +1,24 @@
+"""pipelines.integration_id — source integration, for stateless reconcile polling
+
+Revision ID: c5d9f3a2b8e1
+Revises: b4c8e2f1a9d3
+Create Date: 2026-07-14 11:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'c5d9f3a2b8e1'
+down_revision = 'b4c8e2f1a9d3'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column('pipelines', sa.Column('integration_id', sa.String(length=255), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('pipelines', 'integration_id')


### PR DESCRIPTION
## What

Two related pipeline/CI improvements.

### Expandable CI rows + self-healing reconcile
- `Pipeline.run_id` links a pipeline to the Run it imported; new `GET /pipelines/{id}/cases` returns that run's test cases so a pipeline row expands to show individual tests.
- CI collectors (GitHub/GitLab) now record the produced run.
- Fixes rows stuck on **running** when the in-memory dispatch orchestrator dies or the process restarts: `Pipeline.integration_id` lets a stateless `POST /pipelines/reconcile` re-query the provider for the real status, import results, and finalize the row. The pipelines page poll calls it so rows self-heal.

### Test health includes CI runs
- `persist_import_result` didn't set `created_at`, and the Test health chart excludes runs without it — so every CI/file-imported run was invisible. Now set on import.

## Tests
`backend/tests/test_ci_pipeline_row.py` (+ cases/reconcile), `test_import_execute.py` (created_at). Migrations: `b4c8e2f1a9d3`, `c5d9f3a2b8e1`.

## Note
Stacks on unmerged `feat/record-history` work — until that lands in `main`, this PR also shows 6 prerequisite commits (notifications/pagination/audit). Rebase onto `main` after they merge for a clean diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)