### PR TITLE
feat(overview): backfill test steps from specs + link activity target ids

### DIFF
--- a/frontend/app.jsx
+++ b/frontend/app.jsx
@@ -71,6 +71,7 @@ function App({ currentUser: initialUser, onLogout, onProfileUpdate }) {
   const [importNonce, setImportNonce] = useState(0);
   const [testId, setTestId] = useState(initial.testId);
   const [runId, setRunId] = useState(initial.runId);
+  const [defectFocus, setDefectFocus] = useState(null);   // BUG id to pre-filter the defects list
   const currentUser = initialUser;
   const [toastMsg, setToastMsg] = React.useState(null);
   const [toastSeverity, setToastSeverity] = React.useState(null);
@@ -130,6 +131,7 @@ function App({ currentUser: initialUser, onLogout, onProfileUpdate }) {
 
   const openTest = (id) => { setTestId(id); setView("test-detail"); };
   const openRun = (id) => { setRunId(id); setView("run-detail"); };
+  const openDefect = (id) => { setDefectFocus(id); setView("defects"); };
 
   const W = { label: "ThoroTest", href: "#/overview" };
   let crumbs = [W, "Overview"];
@@ -140,7 +142,7 @@ function App({ currentUser: initialUser, onLogout, onProfileUpdate }) {
   switch (view) {
     case "overview":
       crumbs = [W, "Overview"];
-      body = <Overview onNav={nav} currentUser={currentUser} />;
+      body = <Overview onNav={nav} onOpenTest={openTest} onOpenRun={openRun} onOpenDefect={openDefect} currentUser={currentUser} />;
       break;
     case "library":
       crumbs = [W, "Test library"];
@@ -168,7 +170,7 @@ function App({ currentUser: initialUser, onLogout, onProfileUpdate }) {
       break;
     case "defects":
       crumbs = [W, "Defects"];
-      body = <Defects currentUser={currentUser} />;
+      body = <Defects focusId={defectFocus} currentUser={currentUser} />;
       break;
     case "requirements":
       crumbs = [W, "Requirements"];
@@ -211,7 +213,7 @@ function App({ currentUser: initialUser, onLogout, onProfileUpdate }) {
       hideTopbar = true;
       break;
     default:
-      body = <Overview onNav={nav} currentUser={currentUser} />;
+      body = <Overview onNav={nav} onOpenTest={openTest} onOpenRun={openRun} onOpenDefect={openDefect} currentUser={currentUser} />;
   }
 
   return (

--- a/frontend/views/view-defects.jsx
+++ b/frontend/views/view-defects.jsx
@@ -1,9 +1,9 @@
 // Global defects view — list, filter, manage all defects
 
-function Defects() {
+function Defects({ focusId }) {
   const [defects, setDefects] = useState([]);
   const [loading, setLoading] = useState(true);
-  const [search, setSearch] = useState("");
+  const [search, setSearch] = useState(focusId || "");
   const [filterStatus, setFilterStatus] = useState("all");
   const [filterSeverity, setFilterSeverity] = useState("all");
   const [showCreate, setShowCreate] = useState(false);
@@ -19,6 +19,16 @@ function Defects() {
   };
 
   useEffect(() => { load(); }, [filterStatus, filterSeverity]);
+
+  // Opened from an activity link (BUG-…): pre-filter the list to that defect.
+  useEffect(() => {
+    if (!focusId) return;
+    setSearch(focusId);
+    setLoading(true);
+    TH_API.getDefects({ status: filterStatus, severity: filterSeverity, search: focusId })
+      .then(data => { setDefects(data); setLoading(false); })
+      .catch(() => setLoading(false));
+  }, [focusId]);
 
   useEffect(() => {
     TH_API.getRuns().then(setRuns).catch(() => {});

--- a/frontend/views/view-overview.jsx
+++ b/frontend/views/view-overview.jsx
@@ -13,7 +13,15 @@ function timeAgo(iso) {
   return `${Math.floor(s / 86400 / 7)}w`;
 }
 
-function Overview({ onNav, currentUser }) {
+function Overview({ onNav, onOpenTest, onOpenRun, onOpenDefect, currentUser }) {
+  // Map an activity target id to its opener, or null if it isn't linkable.
+  const targetOpener = (t) => {
+    if (!t) return null;
+    if (onOpenTest && /^TC-/.test(t)) return onOpenTest;
+    if (onOpenRun && /^R-/.test(t)) return onOpenRun;
+    if (onOpenDefect && /^BUG-/.test(t)) return onOpenDefect;
+    return null;
+  };
   const { data: D, loading, error } = useInitialData();
   const [insights, setInsights] = React.useState(null);
   const [health, setHealth] = React.useState(null);
@@ -171,7 +179,16 @@ function Overview({ onNav, currentUser }) {
                   color: a.who.includes("bot") ? "var(--text-muted)" : undefined,
                 }}>{a.who.split(" ").map(x=>x[0]).join("").slice(0,2)}</div>
                 <div style={{flex:1, minWidth:0, lineHeight:1.4}}>
-                  <div style={{fontSize:12}}><b>{a.who}</b> <span className="muted">{a.what}</span> <span className="mono" style={{color:"var(--accent)"}}>{a.target}</span></div>
+                  <div style={{fontSize:12}}><b>{a.who}</b> <span className="muted">{a.what}</span>{" "}
+                    {(() => {
+                      const open = targetOpener(a.target);
+                      return open
+                        ? <a className="mono" style={{color:"var(--accent)", cursor:"pointer", textDecoration:"underline"}}
+                             title={`Open ${a.target}`}
+                             onClick={() => open(a.target)}>{a.target}</a>
+                        : <span className="mono" style={{color:"var(--accent)"}}>{a.target}</span>;
+                    })()}
+                  </div>
                   <div style={{fontSize:11.5, color:"var(--text-dim)", marginTop:2}}>{a.detail}</div>
                 </div>
                 <div className="mono dim" style={{fontSize:10.5, flexShrink:0}}>{a.created_at ? timeAgo(a.created_at) : a.when}</div>

--- a/scripts/backfill-steps-from-specs.py
+++ b/scripts/backfill-steps-from-specs.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Reconstruct TestStep rows for test-list entries from their corresponding spec files.
+
+Each test in the DB is named after a test function/spec (`test_list_users_admin_only`,
+Playwright `test('LIB-01: ...')`). We locate the matching function body across
+`backend/tests/*.py` (pytest, via ast) and `e2e/**/*.spec.ts` (Playwright, via
+brace matching), feed the body to the same Anthropic model the app uses, and
+insert the returned Given/When/Then steps as `test_steps` rows.
+
+Dry-run by default. Pass --commit to write. Idempotent: skips tests that already
+have steps unless --force.
+
+  ./venv/bin/python scripts/backfill-steps-from-specs.py --limit 8
+  ./venv/bin/python scripts/backfill-steps-from-specs.py --limit 8 --commit
+"""
+import argparse
+import ast
+import glob
+import json
+import os
+import re
+import sqlite3
+import sys
+
+from dotenv import load_dotenv
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+load_dotenv(os.path.join(ROOT, ".env"))
+
+SYSTEM = (
+    "You convert a single automated test function into human-readable manual "
+    "test steps. Return ONLY a JSON array (no markdown) of objects, each with "
+    '"action" (imperative, what the tester does) and "expected_result" (what '
+    "should be observed; empty string if the step only sets up state). "
+    "Derive steps from the arrange/act/assert structure of the code. "
+    "Keep it concise: 2-6 steps. Do not invent behaviour not present in the code."
+)
+
+
+def index_pytest(paths):
+    """name -> source segment for every top-level/method test_ function."""
+    out = {}
+    for f in paths:
+        src = open(f).read()
+        try:
+            tree = ast.parse(src)
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name.startswith("test_"):
+                seg = ast.get_source_segment(src, node)
+                if seg and node.name not in out:
+                    out[node.name] = (os.path.relpath(f, ROOT), seg)
+    return out
+
+
+def index_playwright(paths):
+    """test('name', ...) -> body via brace matching."""
+    out = {}
+    pat = re.compile(r"""test(?:\.\w+)?\(\s*['"]([^'"]+)['"]\s*,""")
+    for f in paths:
+        src = open(f).read()
+        for m in pat.finditer(src):
+            name = m.group(1)
+            # find first { after the match, then brace-match to its close
+            i = src.find("{", m.end())
+            if i < 0:
+                continue
+            depth, j = 0, i
+            while j < len(src):
+                c = src[j]
+                if c == "{":
+                    depth += 1
+                elif c == "}":
+                    depth -= 1
+                    if depth == 0:
+                        break
+                j += 1
+            body = src[i : j + 1]
+            out.setdefault(name, (os.path.relpath(f, ROOT), body))
+    return out
+
+
+def base_name(title):
+    """Strip pytest parametrize suffix: test_x[/api/foo] -> test_x."""
+    return title.split("[", 1)[0]
+
+
+def call_llm(client, model, body):
+    msg = client.messages.create(
+        model=model,
+        max_tokens=1024,
+        system=SYSTEM,
+        messages=[{"role": "user", "content": f"Test function:\n\n{body}"}],
+    )
+    text = next((b.text for b in msg.content if isinstance(getattr(b, "text", None), str)), "").strip()
+    if text.startswith("```"):
+        text = text.split("\n", 1)[1].rsplit("```", 1)[0].strip()
+    data = json.loads(text)
+    # Normalize shape variance: {"steps":[...]} wrapper, or list of bare strings.
+    if isinstance(data, dict):
+        data = data.get("steps", [])
+    out = []
+    for s in data:
+        if isinstance(s, str):
+            out.append({"action": s, "expected_result": ""})
+        elif isinstance(s, dict):
+            out.append({"action": s.get("action", ""), "expected_result": s.get("expected_result", "")})
+    return [s for s in out if s["action"]]
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--db", default="presentation.db")
+    ap.add_argument("--limit", type=int, default=8, help="max tests to process")
+    ap.add_argument("--commit", action="store_true", help="write steps (default: dry run)")
+    ap.add_argument("--force", action="store_true", help="rebuild steps even if test already has some")
+    args = ap.parse_args()
+
+    if os.getenv("AI_PROVIDER", "anthropic").lower() != "anthropic" or not os.getenv("ANTHROPIC_API_KEY"):
+        sys.exit("Need AI_PROVIDER=anthropic and ANTHROPIC_API_KEY in .env")
+    from anthropic import Anthropic
+
+    client = Anthropic(api_key=os.getenv("ANTHROPIC_API_KEY"))
+    model = os.getenv("AI_MODEL", "claude-sonnet-5")
+
+    specs = {}
+    specs.update(index_pytest(glob.glob(os.path.join(ROOT, "backend/tests/*.py"))))
+    specs.update(index_playwright(glob.glob(os.path.join(ROOT, "e2e/**/*.spec.ts"), recursive=True)))
+    print(f"indexed {len(specs)} spec functions")
+
+    db = sqlite3.connect(os.path.join(ROOT, args.db))
+    have_steps = {r[0] for r in db.execute("select distinct test_id from test_steps")}
+
+    rows = db.execute("select id, title from tests order by id").fetchall()
+    processed = 0
+    for test_id, title in rows:
+        if processed >= args.limit:
+            break
+        if test_id in have_steps and not args.force:
+            continue
+        spec = specs.get(base_name(title))
+        if not spec:
+            continue
+        path, body = spec
+        try:
+            steps = call_llm(client, model, body)
+        except Exception as e:
+            print(f"  ! {test_id} {title}: LLM/parse error: {e}")
+            continue
+        processed += 1
+        print(f"\n[{processed}] {test_id}  {title}\n    from {path}")
+        for i, s in enumerate(steps, 1):
+            act = s.get("action", "")
+            exp = s.get("expected_result", "")
+            print(f"    {i}. {act}" + (f"  ⇒ {exp}" if exp else ""))
+        if args.commit:
+            if args.force:
+                db.execute("delete from test_steps where test_id=?", (test_id,))
+            for i, s in enumerate(steps, 1):
+                db.execute(
+                    "insert into test_steps (test_id, \"order\", action, expected_result) values (?,?,?,?)",
+                    (test_id, i, s.get("action", ""), s.get("expected_result") or None),
+                )
+            db.commit()  # per-test commit → resumable if interrupted
+    if args.commit:
+        print(f"\ncommitted steps for {processed} tests")
+    else:
+        print(f"\nDRY RUN — {processed} tests previewed. Re-run with --commit to write.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

### Backfill test steps from spec files
- Script `scripts/backfill-steps-from-specs.py`: reconstructs `TestStep` rows for test-list entries by matching each test's title to its function/spec across `backend/tests/*.py` (pytest, via `ast`) and `e2e/**/*.spec.ts` (Playwright, via brace matching), then generating human-readable steps with the same Anthropic model the app uses.
- Dry-run by default, per-test commit (resumable), idempotent (skips tests that already have steps).

### Link activity target ids
- In the Overview activity feed, a target id is now a link: `TC-…` opens the test, `R-…` opens the run, `BUG-…` opens the defects list pre-filtered to that id. Non-matching targets stay plain text.

## Note
Stacks on unmerged `feat/record-history` work — until that lands in `main`, this PR also shows the prerequisite commits. Rebase onto `main` after they merge for a clean diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)