### PR TITLE
feat: Ask AI prompt + folder sync/tree improvements

### DIFF
--- a/backend/github_sync.py
+++ b/backend/github_sync.py
@@ -14,6 +14,7 @@ import uuid
 from datetime import datetime, timezone
 
 import httpx
+from sqlalchemy import func
 
 from . import models
 from .importers import parse_yaml_test
@@ -134,18 +135,20 @@ def _get_or_create_folder(db, path: str, cache: dict) -> str | None:
     """Resolve a "A/B/C" folder path to a folder id, creating missing levels."""
     if not path:
         return None
-    if path in cache:
-        return cache[path]
+    # Cache keys and folder matching are case-insensitive so "e2e" and "E2E"
+    # resolve to one folder instead of creating a duplicate on the next sync.
+    if path.lower() in cache:
+        return cache[path.lower()]
     parts = [p.strip() for p in path.split("/") if p.strip()]
     parent_id = None
     current = ""
     for part in parts:
-        current = f"{current}/{part}" if current else part
+        current = f"{current}/{part.lower()}" if current else part.lower()
         if current in cache:
             parent_id = cache[current]
             continue
         existing = db.query(models.Folder).filter(
-            models.Folder.name == part,
+            func.lower(models.Folder.name) == part.lower(),
             models.Folder.parent_id == parent_id,
         ).first()
         if existing:
@@ -157,7 +160,7 @@ def _get_or_create_folder(db, path: str, cache: dict) -> str | None:
             db.flush()
             cache[current] = fid
             parent_id = fid
-    return cache.get(path)
+    return parent_id
 
 
 def _fetch_files(repo_url: str, branch: str, path: str, token: str | None):

--- a/backend/routers/ai.py
+++ b/backend/routers/ai.py
@@ -144,12 +144,14 @@ async def _call_openai(system: str, user: str, max_tokens: int) -> str:
         raise HTTPException(status_code=503, detail=f"AI service unavailable (upstream rejected request: {_upstream_message(e)})")
 
 
-async def _call_json(system: str, user: str, max_tokens: int = 2048) -> dict:
+async def _call_text(system: str, user: str, max_tokens: int) -> str:
     if _provider() == "anthropic":
-        text = await _call_anthropic(system, user, max_tokens)
-    else:
-        text = await _call_openai(system, user, max_tokens)
-    text = text.strip()
+        return await _call_anthropic(system, user, max_tokens)
+    return await _call_openai(system, user, max_tokens)
+
+
+async def _call_json(system: str, user: str, max_tokens: int = 2048) -> dict:
+    text = (await _call_text(system, user, max_tokens)).strip()
     if text.startswith("```"):
         text = text.split("\n", 1)[1].rsplit("```", 1)[0].strip()
     try:
@@ -170,6 +172,12 @@ class SuggestEdgeCasesRequest(BaseModel):
 
 class AnalyzeFlakyRequest(BaseModel):
     test_id: str
+
+
+class PromptRequest(BaseModel):
+    prompt: str
+    system: Optional[str] = None
+    max_tokens: int = 1024  # clamped to [1, 4096]
 
 
 # System prompts
@@ -197,6 +205,12 @@ _ANALYZE_SYSTEM = (
     "patterns causing inconsistent results. "
     "Return ONLY valid JSON: {\"diagnosis\": \"...\", \"recommendations\": [\"...\", \"...\"]}. "
     "No markdown, no other text."
+)
+
+_PROMPT_DEFAULT_SYSTEM = (
+    "You are a QA assistant embedded in a manual test management tool. "
+    "Help testers with test design, coverage, and quality engineering questions. "
+    "Be concise and practical."
 )
 
 
@@ -288,3 +302,21 @@ async def analyze_flaky(
         user=f"Run history (most recent first):\n{json.dumps(history, indent=2)}",
     )
     return result
+
+
+@router.post("/ai/prompt")
+async def prompt(
+    payload: PromptRequest,
+    current_user: models.User = WRITE_ROLES,
+    db: Session = Depends(get_db),
+):
+    prompt_text = payload.prompt.strip()
+    if not prompt_text:
+        raise HTTPException(status_code=422, detail="prompt is required")
+    _ensure_configured()
+    await _check_rate(current_user.id)
+
+    max_tokens = max(1, min(payload.max_tokens, 4096))
+    system = (payload.system or "").strip() or _PROMPT_DEFAULT_SYSTEM
+    text = await _call_text(system=system, user=prompt_text, max_tokens=max_tokens)
+    return {"response": text}

--- a/backend/routers/folders.py
+++ b/backend/routers/folders.py
@@ -21,6 +21,9 @@ def _build_tree(folders: list, parent_id=None) -> list:
                 id=f.id, name=f.name, parent_id=f.parent_id,
                 project_id=f.project_id, count=f.count, children=children,
             ))
+    # Alphabetical (case-insensitive) at every level so the folder tree and every
+    # folder picker render in a stable, predictable order.
+    result.sort(key=lambda fo: fo.name.lower())
     return result
 
 

--- a/backend/tests/test_ai.py
+++ b/backend/tests/test_ai.py
@@ -149,6 +149,56 @@ class TestAnalyzeFlaky:
         assert resp.status_code == 422
 
 
+class TestPrompt:
+    def _mock_text(self, text):
+        mock = MagicMock()
+        mock.messages.create = AsyncMock(return_value=MockMessage(text))
+        return mock
+
+    def test_prompt_returns_response(self, client, monkeypatch):
+        monkeypatch.setattr(ai_module, "_ai_client", self._mock_text("Test the empty-cart checkout path."))
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key-xxx")
+
+        resp = client.post("/api/ai/prompt", json={"prompt": "Suggest a test idea"})
+
+        assert resp.status_code == 200
+        assert resp.json()["response"] == "Test the empty-cart checkout path."
+
+    def test_prompt_empty_422(self, client, monkeypatch):
+        monkeypatch.setattr(ai_module, "_ai_client", self._mock_text("x"))
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key-xxx")
+
+        resp = client.post("/api/ai/prompt", json={"prompt": "   "})
+        assert resp.status_code == 422
+
+    def test_prompt_custom_system_and_clamped_tokens(self, client, monkeypatch):
+        mock = self._mock_text("ok")
+        monkeypatch.setattr(ai_module, "_ai_client", mock)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key-xxx")
+
+        resp = client.post(
+            "/api/ai/prompt",
+            json={"prompt": "hi", "system": "You are terse.", "max_tokens": 999999},
+        )
+        assert resp.status_code == 200
+        _, kwargs = mock.messages.create.call_args
+        assert kwargs["system"] == "You are terse."
+        assert kwargs["max_tokens"] == 4096  # clamped
+
+    def test_prompt_missing_key_503(self, client, monkeypatch):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.setattr(ai_module, "_ai_client", None)
+
+        resp = client.post("/api/ai/prompt", json={"prompt": "hi"})
+        assert resp.status_code == 503
+
+    def test_viewer_cannot_prompt(self, auth_client, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key-xxx")
+        viewer = auth_client("viewer")
+        resp = viewer.post("/api/ai/prompt", json={"prompt": "hi"})
+        assert resp.status_code == 403
+
+
 class TestRateLimit:
     def test_rate_limit_enforced(self, client, monkeypatch):
         import collections

--- a/e2e/suite-p4-ai-assistant/ai-assistant.spec.ts
+++ b/e2e/suite-p4-ai-assistant/ai-assistant.spec.ts
@@ -98,10 +98,10 @@ test.describe('Suite P4 — AI Assistant', () => {
     await page.click('button.btn.sm:has-text("Suggest edge cases")');
     await expect(page.locator('.card-title:has-text("Suggest edge cases")')).toBeVisible();
 
-    // Without folder context: action button (not the tab) should be disabled + warning shown
+    // The panel now has a folder picker that auto-selects the first folder with
+    // tests, so the action button is enabled (no "navigate to a folder" gate).
     const suggestBtn = page.locator('button.btn.primary:not(.sm):has-text("Suggest edge cases")');
-    await expect(suggestBtn).toBeDisabled();
-    await expect(page.locator('text=Navigate to a folder first')).toBeVisible();
+    await expect(suggestBtn).toBeEnabled();
 
     // Verify API response structure via TH_API direct call (bypasses UI gate)
     const result = await page.evaluate(async (mockData) => {
@@ -185,8 +185,9 @@ test.describe('Suite P4 — AI Assistant', () => {
     await expect(descInput).toBeVisible();
     await descInput.fill('User login scenarios');
 
-    // Count selector visible (default 3)
-    const countSelect = page.locator('select.select');
+    // Count selector visible (default 3). The panel now also has a "Save to
+    // folder" select, so scope to the one with numeric options.
+    const countSelect = page.locator('select.select').filter({ has: page.locator('option[value="10"]') });
     await expect(countSelect).toBeVisible();
     await countSelect.selectOption('2');
 
@@ -229,8 +230,10 @@ test.describe('Suite P4 — AI Assistant', () => {
     await page.click('button.btn.sm:has-text("Suggest edge cases")');
     await expect(page.locator('.card-title:has-text("Suggest edge cases")')).toBeVisible();
 
-    // Button disabled when no folder
-    await expect(page.locator('button.btn.primary:not(.sm):has-text("Suggest edge cases")')).toBeDisabled();
+    // Panel is folder-aware: a folder picker auto-selects a folder with tests,
+    // so the action button is enabled.
+    await expect(page.locator('.card-b select.select')).toBeVisible();
+    await expect(page.locator('button.btn.primary:not(.sm):has-text("Suggest edge cases")')).toBeEnabled();
 
     // Inject results directly to test the suggestion rendering and "Generate test" prefill
     await page.evaluate(async (suggestions) => {

--- a/frontend/api.js
+++ b/frontend/api.js
@@ -896,6 +896,18 @@
       return res.json();
     },
 
+    async aiPrompt(payload) {
+      const res = await fetch(BASE + "/api/ai/prompt", {
+        method: "POST",
+        headers: authHeaders(),
+        body: JSON.stringify(payload),
+      });
+      if (res.status === 429) { const e = await res.json().catch(() => ({})); throw new Error(e.detail || "Rate limit exceeded: try again in an hour"); }
+      if (res.status === 503) { const e = await res.json().catch(() => ({})); throw new Error(e.detail || "AI not configured"); }
+      if (!res.ok) { const e = await res.json().catch(() => ({})); throw new Error(e.detail || "AI request failed"); }
+      return res.json();
+    },
+
     async exportRunCSV(runId) {
       const res = await fetch(BASE + `/api/runs/${runId}/export?format=csv`, { headers: authHeaders() });
       if (!res.ok) throw new Error("Export failed");

--- a/frontend/views/view-config.jsx
+++ b/frontend/views/view-config.jsx
@@ -856,8 +856,28 @@ function Integrations() {
 }
 
 function AIAssistant({ currentUser, currentFolderId }) {
-  // Active panel: "generate" | "edge-cases"
+  // Active panel: "generate" | "edge-cases" | "ask"
   const [panel, setPanel] = React.useState("generate");
+
+  // Folder list for the edge-cases picker. Walk the tree (any depth) building
+  // full ancestor paths, and count direct tests per folder so the dropdown
+  // shows only folders that actually have tests to analyze.
+  const { data: appData } = useInitialData();
+  const folderPaths = {};
+  const folderCounts = {};
+  (function walk(list, prefix) {
+    (list || []).forEach(f => {
+      const path = prefix ? `${prefix} ‹ ${f.name}` : f.name;
+      folderPaths[f.id] = path;
+      walk(f.children, path);
+    });
+  })(appData?.folders, "");
+  (appData?.tests || []).forEach(t => {
+    const fid = t.folder || t.folder_id;
+    if (fid) folderCounts[fid] = (folderCounts[fid] || 0) + 1;
+  });
+  const folderIds = Object.keys(folderCounts)
+    .sort((a, b) => (folderPaths[a] || a).localeCompare(folderPaths[b] || b));
 
   // --- Generate Tests state ---
   const [genDesc, setGenDesc] = React.useState("");
@@ -868,11 +888,23 @@ function AIAssistant({ currentUser, currentFolderId }) {
   const [genSelected, setGenSelected] = React.useState({});  // {index: bool}
   const [genSaving, setGenSaving] = React.useState(false);
   const [genSaveError, setGenSaveError] = React.useState(null);
+  const [genFolderId, setGenFolderId] = React.useState(currentFolderId || "");  // destination for saved tests
 
   // --- Edge Cases state ---
+  const [ecFolderId, setEcFolderId] = React.useState(currentFolderId || "");
   const [ecLoading, setEcLoading] = React.useState(false);
   const [ecError, setEcError] = React.useState(null);
   const [ecResults, setEcResults] = React.useState(null);    // {suggestions: [{title, rationale}]}
+  // Default the picker to the folder the user came from, else the first with tests.
+  React.useEffect(() => {
+    if (!ecFolderId) setEcFolderId(currentFolderId || folderIds[0] || "");
+  }, [currentFolderId, folderIds.length]);
+
+  // --- Ask AI (free prompt) state ---
+  const [askPrompt, setAskPrompt] = React.useState("");
+  const [askLoading, setAskLoading] = React.useState(false);
+  const [askError, setAskError] = React.useState(null);
+  const [askAnswer, setAskAnswer] = React.useState(null);
 
   const handleGenerate = () => {
     if (!genDesc.trim()) return;
@@ -902,7 +934,7 @@ function AIAssistant({ currentUser, currentFolderId }) {
         const tc = genResults[i];
         const created = await TH_API.createTest({
           title: tc.title,
-          folder_id: currentFolderId || null,
+          folder_id: genFolderId || null,
           status: "pending",
         });
         if (tc.steps && tc.steps.length > 0) {
@@ -923,12 +955,23 @@ function AIAssistant({ currentUser, currentFolderId }) {
   };
 
   const handleSuggest = () => {
+    if (!ecFolderId) return;
     setEcLoading(true);
     setEcError(null);
     setEcResults(null);
-    TH_API.suggestEdgeCases({ folder_id: currentFolderId || null })
+    TH_API.suggestEdgeCases({ folder_id: ecFolderId })
       .then(data => { setEcResults(data); setEcLoading(false); })
       .catch(err => { setEcError(err.message); setEcLoading(false); });
+  };
+
+  const handleAsk = () => {
+    if (!askPrompt.trim()) return;
+    setAskLoading(true);
+    setAskError(null);
+    setAskAnswer(null);
+    TH_API.aiPrompt({ prompt: askPrompt.trim() })
+      .then(data => { setAskAnswer(data.response || ""); setAskLoading(false); })
+      .catch(err => { setAskError(err.message); setAskLoading(false); });
   };
 
   const anySelected = genResults && Object.values(genSelected).some(Boolean);
@@ -953,6 +996,10 @@ function AIAssistant({ currentUser, currentFolderId }) {
           className={"btn sm" + (panel === "edge-cases" ? " primary" : "")}
           onClick={() => setPanel("edge-cases")}
         >Suggest edge cases</button>
+        <button
+          className={"btn sm" + (panel === "ask" ? " primary" : "")}
+          onClick={() => setPanel("ask")}
+        >Ask AI</button>
       </div>
 
       {/* Generate Tests panel */}
@@ -986,6 +1033,21 @@ function AIAssistant({ currentUser, currentFolderId }) {
                 {[1,2,3,4,5,6,7,8,9,10].map(n => <option key={n} value={n}>{n}</option>)}
               </select>
             </div>
+            <div className="field" style={{marginBottom:14}}>
+              <label className="field-label">Save to folder</label>
+              <select
+                className="select"
+                style={{width:"100%", maxWidth:480}}
+                value={genFolderId}
+                onChange={e => setGenFolderId(e.target.value)}
+                disabled={genLoading || genSaving}
+              >
+                <option value="">No folder</option>
+                {folderIds.map(id => (
+                  <option key={id} value={id}>{(folderPaths[id] || id) + ` (${folderCounts[id] || 0})`}</option>
+                ))}
+              </select>
+            </div>
             <div style={{display:"flex", gap:6, alignItems:"center"}}>
               <button
                 className="btn primary"
@@ -1002,7 +1064,9 @@ function AIAssistant({ currentUser, currentFolderId }) {
               <div style={{marginTop:16}}>
                 <div style={{fontSize:12, fontWeight:500, marginBottom:10, color:"var(--text-muted)"}}>
                   {genResults.length} test case{genResults.length !== 1 ? "s" : ""} generated — select which to save
-                  {currentFolderId ? null : <span style={{color:"var(--warn)", marginLeft:8}}>(no folder selected — tests saved without folder)</span>}
+                  <span style={{marginLeft:8, color: genFolderId ? "var(--text-muted)" : "var(--warn)"}}>
+                    {genFolderId ? `→ ${folderPaths[genFolderId] || genFolderId}` : "(no folder — saved without folder)"}
+                  </span>
                 </div>
                 <div style={{display:"flex", flexDirection:"column", gap:8}}>
                   {genResults.map((tc, i) => (
@@ -1053,22 +1117,33 @@ function AIAssistant({ currentUser, currentFolderId }) {
         <div className="card">
           <div className="card-h">
             <div className="card-title">Suggest edge cases</div>
-            <div className="card-sub">
-              {currentFolderId
-                ? `Analyzing tests in folder ${currentFolderId} for missing coverage.`
-                : "Navigate to a folder to see edge case suggestions."}
-            </div>
+            <div className="card-sub">Pick a folder — AI compares its existing tests and flags uncovered edge cases.</div>
           </div>
           <div className="card-b">
-            {!currentFolderId && (
+            {folderIds.length === 0 ? (
               <div style={{fontSize:12, color:"var(--text-muted)", marginBottom:12}}>
-                Navigate to a folder first to enable edge case suggestions.
+                No folders with tests yet. Create some tests first.
+              </div>
+            ) : (
+              <div className="field" style={{marginBottom:14}}>
+                <label className="field-label">Folder</label>
+                <select
+                  className="select"
+                  style={{width:"100%", maxWidth:480}}
+                  value={ecFolderId}
+                  onChange={e => { setEcFolderId(e.target.value); setEcResults(null); setEcError(null); }}
+                  disabled={ecLoading}
+                >
+                  {folderIds.map(id => (
+                    <option key={id} value={id}>{(folderPaths[id] || id) + ` (${folderCounts[id] || 0})`}</option>
+                  ))}
+                </select>
               </div>
             )}
             <button
               className="btn primary"
               onClick={handleSuggest}
-              disabled={ecLoading || !currentFolderId}
+              disabled={ecLoading || !ecFolderId}
             >
               {ecLoading ? "Analyzing…" : <><Icon name="sparkle" /> Suggest edge cases</>}
             </button>
@@ -1093,12 +1168,55 @@ function AIAssistant({ currentUser, currentFolderId }) {
                         style={{background:"var(--purple)", color:"oklch(0.16 0 0)", borderColor:"var(--purple)"}}
                         onClick={() => {
                           setGenDesc(s.title);
+                          if (ecFolderId) setGenFolderId(ecFolderId);
                           setPanel("generate");
                         }}
                       >Generate test</button>
                     </div>
                   ));
                 })()}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Ask AI panel — free-form prompt */}
+      {panel === "ask" && (
+        <div className="card">
+          <div className="card-h">
+            <div className="card-title">Ask AI</div>
+            <div className="card-sub">Ask any QA or test-design question — free-form, no structure required.</div>
+          </div>
+          <div className="card-b">
+            <div className="field" style={{marginBottom:12}}>
+              <label className="field-label">Your prompt</label>
+              <textarea
+                className="textarea"
+                style={{minHeight:100, fontFamily:"var(--font-sans)", width:"100%"}}
+                value={askPrompt}
+                onChange={e => setAskPrompt(e.target.value)}
+                placeholder="e.g. What boundary conditions should I test for a date-range filter?"
+                disabled={askLoading}
+                onKeyDown={e => { if ((e.metaKey || e.ctrlKey) && e.key === "Enter") handleAsk(); }}
+              />
+            </div>
+            <div style={{display:"flex", gap:6, alignItems:"center"}}>
+              <button
+                className="btn primary"
+                onClick={handleAsk}
+                disabled={askLoading || !askPrompt.trim()}
+              >
+                {askLoading ? "Thinking…" : <><Icon name="sparkle" /> Ask</>}
+              </button>
+              <span style={{fontSize:11, color:"var(--text-muted)"}}>⌘/Ctrl+Enter</span>
+            </div>
+            {askError && (
+              <div style={{fontSize:12, color:"var(--fail)", marginTop:10}}>{askError}</div>
+            )}
+            {askAnswer != null && (
+              <div style={{marginTop:16, padding:"14px 16px", border:"1px solid var(--border)", borderRadius:6, background:"var(--bg-2)", fontSize:13, lineHeight:1.7, whiteSpace:"pre-wrap"}}>
+                {askAnswer || <span style={{color:"var(--text-muted)"}}>(empty response)</span>}
               </div>
             )}
           </div>

--- a/frontend/views/view-docs.jsx
+++ b/frontend/views/view-docs.jsx
@@ -380,10 +380,14 @@ function CliSection() {
 
   return (
     <div style={{ maxWidth: 700 }}>
-      <div className="page-title" style={{ fontSize: 18, marginBottom: 4 }}>CLI</div>
+      <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 4 }}>
+        <div className="page-title" style={{ fontSize: 18 }}>CLI</div>
+        <span style={{ fontSize: 10.5, fontWeight: 600, textTransform: "uppercase", letterSpacing: 0.5, color: "var(--text-dim)", border: "1px solid var(--border)", borderRadius: 4, padding: "2px 6px" }}>
+          Coming soon
+        </span>
+      </div>
       <div style={{ fontSize: 12.5, color: "var(--text-muted)", marginBottom: 20, lineHeight: 1.6 }}>
-        <code style={{ fontFamily: "var(--font-mono)" }}>npm install -g @thorotest/cli</code>
-        &nbsp;·&nbsp; Requires Node 18+
+        Not yet published. The commands below preview the planned CLI · Requires Node 18+
       </div>
       <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
         {cmds.map(c => (

--- a/frontend/views/view-library.jsx
+++ b/frontend/views/view-library.jsx
@@ -1,5 +1,56 @@
 // Library view — test case management
 
+// Flatten the folder tree to a flat list at any depth (imported spec folders
+// nest several levels deep). Used for the folder tree, the active-folder title
+// lookup, and the bulk "move to folder" picker.
+function flattenFolders(list) {
+  const out = [];
+  (list || []).forEach(f => {
+    out.push(f);
+    if (f.children) out.push(...flattenFolders(f.children));
+  });
+  return out;
+}
+
+// One folder row, rendered recursively so nested subfolders (any depth) are
+// navigable — the old tree only rendered the top two levels.
+function FolderRow({ node, depth, openFolders, toggleFolder, selectFolder, activeFolder, favoritedIds, toggleFavorite }) {
+  const hasChildren = node.children && node.children.length > 0;
+  const open = !!openFolders[node.id];
+  return (
+    <React.Fragment>
+      <div
+        className={"tree-row" + (activeFolder === node.id ? " active" : "")}
+        style={{paddingLeft: 8 + depth * 16}}
+        onClick={() => { if (hasChildren) toggleFolder(node.id); selectFolder(node.id); }}
+      >
+        <span className={"caret" + (open ? " open" : "")}>{hasChildren ? <Icon name="chev" /> : null}</span>
+        <span style={{color: depth === 0 ? "var(--warn)" : "var(--text-dim)", fontSize: depth === 0 ? undefined : 10}}>{depth === 0 ? "▣" : "—"}</span>
+        <span>{node.name}</span>
+        <span className="count">{node.count}</span>
+        <span
+          title={favoritedIds.has(node.id) ? "Remove from favorites" : "Add to favorites"}
+          style={{marginLeft:"auto", cursor:"pointer", color: favoritedIds.has(node.id) ? "var(--warn)" : "var(--text-dim)", fontSize:12, lineHeight:1}}
+          onClick={(e) => toggleFavorite(e, node.id)}
+        >{favoritedIds.has(node.id) ? "★" : "☆"}</span>
+      </div>
+      {open && hasChildren && node.children.map(c => (
+        <FolderRow
+          key={c.id}
+          node={c}
+          depth={depth + 1}
+          openFolders={openFolders}
+          toggleFolder={toggleFolder}
+          selectFolder={selectFolder}
+          activeFolder={activeFolder}
+          favoritedIds={favoritedIds}
+          toggleFavorite={toggleFavorite}
+        />
+      ))}
+    </React.Fragment>
+  );
+}
+
 function Library({ onNav, onOpenTest, currentUser }) {
   const [refreshKey, setRefreshKey] = useState(0);
   const { data: D, loading, error } = useInitialData(refreshKey);
@@ -77,12 +128,7 @@ function Library({ onNav, onOpenTest, currentUser }) {
 
   const allFolderIds = useMemo(() => {
     if (!D) return [];
-    const result = [];
-    D.folders.forEach(f => {
-      result.push(f.id);
-      if (f.children) f.children.forEach(c => result.push(c.id));
-    });
-    return result;
+    return flattenFolders(D.folders).map(f => f.id);
   }, [D]);
 
   const allTags = useMemo(() => {
@@ -163,7 +209,7 @@ function Library({ onNav, onOpenTest, currentUser }) {
   );
 
   const totalCount = D.tests.length;
-  const allFoldersList = D.folders.flatMap(f => [f, ...(f.children || [])]);
+  const allFoldersList = flattenFolders(D.folders);
 
   return (
     <div style={{display:"grid", gridTemplateColumns:"260px 1fr", height:"100%", overflow:"hidden"}}>
@@ -184,36 +230,17 @@ function Library({ onNav, onOpenTest, currentUser }) {
             <span className="count">{totalCount}</span>
           </div>
           {D.folders.map(f => (
-            <React.Fragment key={f.id}>
-              <div className={"tree-row" + (activeFolder === f.id ? " active" : "")} onClick={() => { toggleFolder(f.id); selectFolder(f.id); }}>
-                <span className={"caret" + (openFolders[f.id] ? " open" : "")}>{f.children ? <Icon name="chev" /> : null}</span>
-                <span style={{color:"var(--warn)"}}>▣</span>
-                <span>{f.name}</span>
-                <span className="count">{f.count}</span>
-                <span
-                  title={favoritedIds.has(f.id) ? "Remove from favorites" : "Add to favorites"}
-                  style={{marginLeft:"auto", cursor:"pointer", color: favoritedIds.has(f.id) ? "var(--warn)" : "var(--text-dim)", fontSize:12, lineHeight:1}}
-                  onClick={(e) => toggleFavorite(e, f.id)}
-                >{favoritedIds.has(f.id) ? "★" : "☆"}</span>
-              </div>
-              {openFolders[f.id] && f.children && f.children.map(c => (
-                <div
-                  key={c.id}
-                  className={"tree-row" + (activeFolder === c.id ? " active" : "")}
-                  style={{paddingLeft: 28}}
-                  onClick={() => selectFolder(c.id)}
-                >
-                  <span style={{color:"var(--text-dim)", fontSize:10}}>—</span>
-                  <span>{c.name}</span>
-                  <span className="count">{c.count}</span>
-                  <span
-                    title={favoritedIds.has(c.id) ? "Remove from favorites" : "Add to favorites"}
-                    style={{marginLeft:"auto", cursor:"pointer", color: favoritedIds.has(c.id) ? "var(--warn)" : "var(--text-dim)", fontSize:12, lineHeight:1}}
-                    onClick={(e) => toggleFavorite(e, c.id)}
-                  >{favoritedIds.has(c.id) ? "★" : "☆"}</span>
-                </div>
-              ))}
-            </React.Fragment>
+            <FolderRow
+              key={f.id}
+              node={f}
+              depth={0}
+              openFolders={openFolders}
+              toggleFolder={toggleFolder}
+              selectFolder={selectFolder}
+              activeFolder={activeFolder}
+              favoritedIds={favoritedIds}
+              toggleFavorite={toggleFavorite}
+            />
           ))}
         </div>
         <div style={{padding:"10px 12px", borderTop:"1px solid var(--border)", fontSize:11, color:"var(--text-dim)"}}>
@@ -230,7 +257,7 @@ function Library({ onNav, onOpenTest, currentUser }) {
         {/* Toolbar */}
         <div className="toolbar">
           <div style={{fontSize:14, fontWeight:600, marginRight:8}}>
-            {activeFolder ? (D.folders.find(f=>f.id===activeFolder)?.name || D.folders.flatMap(f=>f.children||[]).find(c=>c.id===activeFolder)?.name) : "All tests"}
+            {activeFolder ? (allFoldersList.find(f=>f.id===activeFolder)?.name || activeFolder) : "All tests"}
           </div>
           <div className="card-sub">{testsLoading ? "…" : `${filtered.length} tests`}</div>
           <div className="spacer" />
@@ -471,7 +498,7 @@ function Library({ onNav, onOpenTest, currentUser }) {
       {/* New test modal */}
       {showNewTest && (
         <NewTestModal
-          folders={D.folders.flatMap(f => [f, ...(f.children || [])])}
+          folders={allFoldersList}
           defaultFolderId={activeFolder}
           onClose={() => setShowNewTest(false)}
           onCreate={refresh}


### PR DESCRIPTION
Three independent changes, one commit each.

## feat(ai): free-form "Ask AI" prompt
New `POST /ai/prompt` (write roles, rate-limited) backing an "Ask AI" panel in the AI assistant — testers ask open QA questions, get a plain-text answer. Provider call refactored into `_call_text`. Generate/edge-cases panels gain explicit folder pickers. Tests in `test_ai.py`.

## fix(folders): sync dedup, order, deep tree
- github sync resolves folder paths case-insensitively (no duplicate on re-sync)
- folder tree sorts alphabetically at every level
- library tree renders recursively at any depth (was capped at two levels)

## docs(cli): mark CLI "Coming soon"
CLI isn't published — label the docs section as a preview.

## Review notes
- `_call_json` → `_call_text` refactor in `ai.py` touches an existing path
- `_get_or_create_folder` change in `github_sync.py` alters folder matching
- 39 tests pass (test_ai + test_github_sync + test_migrations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)