### PR TITLE
feat(custom-fields): admin-defined fields on tests, defects, requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,17 @@ This file is the single source of truth for the in-app About page
 (`GET /api/about` parses it), so keep the structure: one `## [x.y.z] - YYYY-MM-DD`
 heading per release, `### <Group>` subsections, `-` bullets.
 
-## [Unreleased]
+## [1.9.0] - 2026-07-16
 
 ### Added
+- Custom fields on tests, defects, and requirements: admins define extra
+  fields (text, number, select, date, checkbox — optionally required) from
+  Admin → Custom Fields; they appear on every create/edit form, on the test
+  detail page, and as chips in the defect table. Values are validated
+  server-side and tracked in each record's change history.
+- Defect edit dialog: title, description, severity, status, and custom
+  fields — defects were previously only editable via the inline status
+  dropdown.
 - `thorotest` CLI v0.1 (beta, in-repo under `cli/`): `status`, `lint`, `sync`,
   `token create` — tests-as-code sync from any CI provider or fully airgapped
   installs, no Git server needed. Zero-dependency Node 18+, full reference in
@@ -18,6 +26,10 @@ heading per release, `### <Group>` subsections, `-` bullets.
 - `POST /api/sync/yaml` — CLI-facing sync endpoint reusing the Git sync
   pipeline (same id/path matching, dry-run support).
 - CI job running the CLI test suite (node:test).
+
+### Fixed
+- Crash ("setTest is not defined") when pushing a git-synced test back to
+  its source repo from the test detail page.
 
 ## [1.8.0] - 2026-07-15
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > **Self-hosted test management that treats manual and automated tests as one timeline.** Organize, run, and track every test — trace features, stories, and epics to the tests that cover them, and see coverage at a glance.
 
-[![version](https://img.shields.io/badge/version-1.8.0-blue)](package.json)
+[![version](https://img.shields.io/badge/version-1.9.0-blue)](package.json)
 [![license](https://img.shields.io/badge/license-MIT%20%2B%20Commons%20Clause-green)](LICENSE)
 [![tests](https://img.shields.io/badge/tests-576%20unit%20%2B%2031%20e2e%20suites-brightgreen)](#tests)
 [![backend](https://img.shields.io/badge/backend-FastAPI-009688)](#stack)

--- a/backend/main.py
+++ b/backend/main.py
@@ -38,7 +38,7 @@ from .ws_manager import manager
 from .notifications import notif_manager
 from .auth_utils import SECRET_KEY, ALGORITHM, get_current_user
 from .gql_schema import graphql_router
-from .routers import folders, tests, runs, plans, pipelines, activity, auth, projects, categories, defects, requirements, integrations, tokens, webhooks, favorites, import_, attachments, admin, ai, notifications, audit_log, oauth, totp, ci, history, sync, about
+from .routers import folders, tests, runs, plans, pipelines, activity, auth, projects, categories, defects, requirements, integrations, tokens, webhooks, favorites, import_, attachments, admin, ai, notifications, audit_log, oauth, totp, ci, history, sync, about, custom_fields
 
 # Serve the built frontend (frontend/dist — produced by `npm run build`).
 # Fall back to the source dir so the API can still boot without a build
@@ -287,6 +287,7 @@ app.include_router(oauth.router, prefix="/api")
 app.include_router(totp.router, prefix="/api")
 app.include_router(sync.router, prefix="/api")
 app.include_router(about.router, prefix="/api")
+app.include_router(custom_fields.router, prefix="/api")
 
 # GraphQL
 app.include_router(graphql_router, prefix="/graphql")

--- a/backend/models.py
+++ b/backend/models.py
@@ -64,6 +64,7 @@ class Test(Base):
     priority = Column(String(32), default="med")
     owner = Column(String(255), nullable=True)
     tags = Column(JSON, default=list)
+    custom_fields = Column(JSON, default=dict)   # {def key: value} — keys defined in custom_field_defs
     auto = Column(Boolean, default=False)
     runner = Column(String(255), nullable=True)
     updated_at = Column(String(64), nullable=True)
@@ -187,6 +188,7 @@ class Defect(Base):
     external_provider = Column(String(64), nullable=True)   # e.g. "jira"
     external_key = Column(String(128), nullable=True)       # e.g. "PROJ-123"
     external_url = Column(String(512), nullable=True)
+    custom_fields = Column(JSON, default=dict)   # {def key: value} — keys defined in custom_field_defs
 
     test_rel = relationship("Test", back_populates="defects")
 
@@ -206,12 +208,31 @@ class Requirement(Base):
     external_provider = Column(String(64), nullable=True)   # e.g. "jira"
     external_key = Column(String(128), nullable=True)       # e.g. "PROJ-45"
     external_url = Column(String(512), nullable=True)
+    custom_fields = Column(JSON, default=dict)   # {def key: value} — keys defined in custom_field_defs
 
     tests = relationship("Test", secondary=requirement_tests, back_populates="requirements")
 
     @property
     def test_ids(self):
         return [t.id for t in self.tests]
+
+
+class CustomFieldDef(Base):
+    """Admin-defined extra field for tests / defects / requirements.
+
+    Values live in the entity's `custom_fields` JSON column, keyed by `key`.
+    """
+    __tablename__ = "custom_field_defs"
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    entity_type = Column(String(32), nullable=False)          # "test" | "defect" | "requirement"
+    key = Column(String(64), nullable=False)                  # machine key, e.g. "browser"
+    label = Column(String(255), nullable=False)               # display name, e.g. "Browser"
+    field_type = Column(String(16), nullable=False, default="text")  # text|number|select|date|checkbox
+    options = Column(JSON, default=list)                      # select only: list[str]
+    required = Column(Boolean, default=False)
+    order = Column(Integer, default=0)                        # display order within entity_type
+
+    __table_args__ = (UniqueConstraint("entity_type", "key", name="uq_custom_field_entity_key"),)
 
 
 class Comment(Base):

--- a/backend/routers/custom_fields.py
+++ b/backend/routers/custom_fields.py
@@ -1,0 +1,198 @@
+"""Custom field definitions — admin-managed extra fields for tests, defects
+and requirements.
+
+Definitions are global (one set per entity type). Values are stored per record
+in the entity's `custom_fields` JSON column; the mutating routers call
+`validate_and_merge()` so every write is checked against the definitions.
+"""
+import re
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from typing import List, Optional
+
+from ..db import get_db
+from .. import models
+from ..schemas import CustomFieldDefOut, CustomFieldDefCreate, CustomFieldDefUpdate
+from ..auth_utils import require_role, get_current_user
+
+router = APIRouter(tags=["custom-fields"])
+
+ADMIN_ONLY = require_role("admin")
+
+ENTITY_TYPES = {"test", "defect", "requirement"}
+FIELD_TYPES = {"text", "number", "select", "date", "checkbox"}
+
+_KEY_RE = re.compile(r"^[a-z0-9_]{1,64}$")
+_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+def _slugify(label: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "_", label.strip().lower()).strip("_")[:64]
+
+
+def _validate_def(entity_type: str, field_type: str, options) -> None:
+    if entity_type not in ENTITY_TYPES:
+        raise HTTPException(status_code=400, detail=f"entity_type must be one of: {', '.join(sorted(ENTITY_TYPES))}")
+    if field_type not in FIELD_TYPES:
+        raise HTTPException(status_code=400, detail=f"field_type must be one of: {', '.join(sorted(FIELD_TYPES))}")
+    if field_type == "select" and not options:
+        raise HTTPException(status_code=400, detail="select fields need at least one option")
+
+
+def _check_value(d: models.CustomFieldDef, v):
+    """Validate one value against its definition. Returns the value to store."""
+    if d.field_type == "text":
+        if not isinstance(v, str):
+            raise HTTPException(status_code=400, detail=f"'{d.key}' must be a string")
+    elif d.field_type == "number":
+        if isinstance(v, bool) or not isinstance(v, (int, float)):
+            raise HTTPException(status_code=400, detail=f"'{d.key}' must be a number")
+    elif d.field_type == "checkbox":
+        if not isinstance(v, bool):
+            raise HTTPException(status_code=400, detail=f"'{d.key}' must be true or false")
+    elif d.field_type == "date":
+        if not isinstance(v, str) or not _DATE_RE.match(v):
+            raise HTTPException(status_code=400, detail=f"'{d.key}' must be a date (YYYY-MM-DD)")
+    elif d.field_type == "select":
+        if v not in (d.options or []):
+            raise HTTPException(status_code=400, detail=f"'{d.key}' must be one of: {', '.join(d.options or [])}")
+    return v
+
+
+def validate_and_merge(
+    db: Session,
+    entity_type: str,
+    incoming: Optional[dict],
+    existing: Optional[dict] = None,
+    *,
+    partial: bool = False,
+) -> dict:
+    """Validate incoming custom-field values and merge them over `existing`.
+
+    - unknown keys → 400
+    - type/option mismatches → 400
+    - null value (or "" ) removes the key
+    - required fields must be present after the merge; on partial updates the
+      check only fires for keys the caller touched (so a PATCH that doesn't
+      mention custom fields never fails on legacy records).
+    """
+    defs = db.query(models.CustomFieldDef).filter(models.CustomFieldDef.entity_type == entity_type).all()
+    by_key = {d.key: d for d in defs}
+    incoming = incoming or {}
+
+    unknown = sorted(set(incoming) - set(by_key))
+    if unknown:
+        raise HTTPException(status_code=400, detail=f"Unknown custom field(s): {', '.join(unknown)}")
+
+    merged = dict(existing or {})
+    for k, v in incoming.items():
+        d = by_key[k]
+        if v is None or v == "":
+            if d.required:
+                raise HTTPException(status_code=400, detail=f"'{k}' is required and cannot be cleared")
+            merged.pop(k, None)
+        else:
+            merged[k] = _check_value(d, v)
+
+    if not partial:
+        missing = [d.key for d in defs if d.required and merged.get(d.key) in (None, "")]
+        if missing:
+            raise HTTPException(status_code=400, detail=f"Missing required custom field(s): {', '.join(sorted(missing))}")
+    return merged
+
+
+def diff_custom_fields(db: Session, entity_type: str, old: Optional[dict], new: Optional[dict]) -> list:
+    """Per-key change entries for record history, labelled with the def's label."""
+    labels = {
+        d.key: d.label
+        for d in db.query(models.CustomFieldDef).filter(models.CustomFieldDef.entity_type == entity_type).all()
+    }
+    old, new = old or {}, new or {}
+    changes = []
+    for k in sorted(set(old) | set(new)):
+        if old.get(k) != new.get(k):
+            changes.append({"field": labels.get(k, k), "old": old.get(k), "new": new.get(k)})
+    return changes
+
+
+@router.get("/custom-fields", response_model=List[CustomFieldDefOut])
+def list_custom_fields(
+    entity_type: Optional[str] = None,
+    db: Session = Depends(get_db),
+    _: models.User = Depends(get_current_user),
+):
+    q = db.query(models.CustomFieldDef)
+    if entity_type:
+        q = q.filter(models.CustomFieldDef.entity_type == entity_type)
+    return q.order_by(models.CustomFieldDef.entity_type, models.CustomFieldDef.order, models.CustomFieldDef.id).all()
+
+
+@router.post("/custom-fields", response_model=CustomFieldDefOut, status_code=201)
+def create_custom_field(
+    payload: CustomFieldDefCreate,
+    db: Session = Depends(get_db),
+    _: models.User = ADMIN_ONLY,
+):
+    _validate_def(payload.entity_type, payload.field_type, payload.options)
+    key = (payload.key or _slugify(payload.label)).strip()
+    if not _KEY_RE.match(key):
+        raise HTTPException(status_code=400, detail="key must be lowercase letters, digits or _ (max 64 chars)")
+    dup = (
+        db.query(models.CustomFieldDef)
+        .filter(models.CustomFieldDef.entity_type == payload.entity_type, models.CustomFieldDef.key == key)
+        .first()
+    )
+    if dup:
+        raise HTTPException(status_code=409, detail=f"Custom field '{key}' already exists for {payload.entity_type}")
+    d = models.CustomFieldDef(
+        entity_type=payload.entity_type,
+        key=key,
+        label=payload.label.strip() or key,
+        field_type=payload.field_type,
+        options=payload.options if payload.field_type == "select" else [],
+        required=payload.required,
+        order=payload.order,
+    )
+    db.add(d)
+    db.commit()
+    db.refresh(d)
+    return d
+
+
+@router.patch("/custom-fields/{def_id}", response_model=CustomFieldDefOut)
+def update_custom_field(
+    def_id: int,
+    payload: CustomFieldDefUpdate,
+    db: Session = Depends(get_db),
+    _: models.User = ADMIN_ONLY,
+):
+    d = db.query(models.CustomFieldDef).filter(models.CustomFieldDef.id == def_id).first()
+    if not d:
+        raise HTTPException(status_code=404, detail="Custom field not found")
+    data = payload.model_dump(exclude_unset=True)
+    field_type = data.get("field_type", d.field_type)
+    options = data.get("options", d.options)
+    _validate_def(d.entity_type, field_type, options)
+    if field_type != "select":
+        data["options"] = []
+    for field, value in data.items():
+        setattr(d, field, value)
+    db.commit()
+    db.refresh(d)
+    return d
+
+
+@router.delete("/custom-fields/{def_id}", status_code=204)
+def delete_custom_field(
+    def_id: int,
+    db: Session = Depends(get_db),
+    _: models.User = ADMIN_ONLY,
+):
+    """Delete a definition. Stored values keep living in each record's JSON
+    blob but are no longer validated, shown, or editable."""
+    d = db.query(models.CustomFieldDef).filter(models.CustomFieldDef.id == def_id).first()
+    if not d:
+        raise HTTPException(status_code=404, detail="Custom field not found")
+    db.delete(d)
+    db.commit()

--- a/backend/routers/defects.py
+++ b/backend/routers/defects.py
@@ -10,8 +10,9 @@ from .. import models
 from ..schemas import DefectOut, DefectCreate, DefectUpdate
 from ..auth_utils import require_role, get_current_user
 from ..activity_utils import log_activity, actor_name
-from ..record_history import log_create, log_update, log_delete
+from ..record_history import log_create, log_update, log_delete, write_changes
 from ._pagination import paginate, MAX_LIMIT
+from .custom_fields import validate_and_merge, diff_custom_fields
 
 router = APIRouter(tags=["defects"])
 
@@ -76,6 +77,7 @@ def create_defect(
         status="open",
         created_at="just now",
         created_by=created_by,
+        custom_fields=validate_and_merge(db, "defect", payload.custom_fields),
     )
     db.add(d)
     log_activity(db, created_by, "filed defect", bug_id, payload.title)
@@ -91,7 +93,13 @@ def update_defect(defect_id: str, payload: DefectUpdate, db: Session = Depends(g
     if not d:
         raise HTTPException(status_code=404, detail="Defect not found")
     data = payload.model_dump(exclude_unset=True)
-    log_update(db, "defect", defect_id, current_user, d, data)
+    incoming_cf = data.pop("custom_fields", None)
+    if incoming_cf is not None:
+        merged_cf = validate_and_merge(db, "defect", incoming_cf, d.custom_fields, partial=True)
+        write_changes(db, "defect", defect_id, current_user,
+                      diff_custom_fields(db, "defect", d.custom_fields, merged_cf))
+        data["custom_fields"] = merged_cf
+    log_update(db, "defect", defect_id, current_user, d, {k: v for k, v in data.items() if k != "custom_fields"})
     for field, value in data.items():
         setattr(d, field, value)
     db.commit()

--- a/backend/routers/requirements.py
+++ b/backend/routers/requirements.py
@@ -14,9 +14,10 @@ from .. import models
 from ..schemas import RequirementOut, RequirementCreate, RequirementUpdate, RequirementCoverage
 from ..auth_utils import require_role, get_current_user
 from ..activity_utils import log_activity
-from ..record_history import log_create, log_update, log_delete
+from ..record_history import log_create, log_update, log_delete, write_changes
 from ..notifications import _notify_assignment
 from ._pagination import paginate, MAX_LIMIT
+from .custom_fields import validate_and_merge, diff_custom_fields
 
 router = APIRouter(tags=["requirements"])
 
@@ -111,6 +112,7 @@ def _serialize(req: models.Requirement) -> RequirementOut:
         description=req.description, owner=req.owner, created_at=req.created_at, created_by=req.created_by,
         external_provider=req.external_provider, external_key=req.external_key, external_url=req.external_url,
         test_ids=req.test_ids, coverage=_coverage(req),
+        custom_fields=req.custom_fields or {},
     )
 
 
@@ -191,6 +193,7 @@ def create_requirement(
         owner=payload.owner,
         created_at="just now",
         created_by=created_by,
+        custom_fields=validate_and_merge(db, "requirement", payload.custom_fields),
     )
     r.tests = _resolve_tests(db, payload.test_ids)
     db.add(r)
@@ -276,9 +279,16 @@ def update_requirement(req_id: str, payload: RequirementUpdate, db: Session = De
     data = payload.model_dump(exclude_unset=True)
     if "test_ids" in data:
         r.tests = _resolve_tests(db, data.pop("test_ids") or [])
+    incoming_cf = data.pop("custom_fields", None)
+    if incoming_cf is not None:
+        merged_cf = validate_and_merge(db, "requirement", incoming_cf, r.custom_fields, partial=True)
+        write_changes(db, "requirement", req_id, current_user,
+                      diff_custom_fields(db, "requirement", r.custom_fields, merged_cf))
+        data["custom_fields"] = merged_cf
     owner_changed = "owner" in data and (data.get("owner") or None) != (r.owner or None)
     new_owner = data.get("owner")
-    log_update(db, "requirement", req_id, current_user, r, data)
+    log_update(db, "requirement", req_id, current_user, r,
+               {k: v for k, v in data.items() if k != "custom_fields"})
     for field, value in data.items():
         setattr(r, field, value)
     db.commit()

--- a/backend/routers/tests.py
+++ b/backend/routers/tests.py
@@ -19,6 +19,7 @@ from ..git_push import find_vcs_integration, PushConflict
 from ..github_sync import push_test as github_push_test
 from ..gitlab_sync import push_test as gitlab_push_test
 from ._pagination import paginate, MAX_LIMIT
+from .custom_fields import validate_and_merge, diff_custom_fields
 
 router = APIRouter(tags=["tests"])
 
@@ -134,6 +135,7 @@ def create_test(payload: TestCreate, db: Session = Depends(get_db), current_user
         raise HTTPException(status_code=409, detail="Test ID already exists")
     data = payload.model_dump()
     data["id"] = test_id
+    data["custom_fields"] = validate_and_merge(db, "test", data.get("custom_fields"))
     t = models.Test(**data)
     db.add(t)
     log_activity(db, actor_name(current_user), "created", test_id, t.title)
@@ -158,9 +160,14 @@ def update_test(test_id: str, payload: TestUpdate, db: Session = Depends(get_db)
         raise HTTPException(status_code=404, detail="Test not found")
     data = payload.model_dump(exclude_unset=True)
     category_ids = data.pop("category_ids", None)
+    incoming_cf = data.pop("custom_fields", None)
     owner_changed = "owner" in data and (data.get("owner") or None) != (t.owner or None)
     new_owner = data.get("owner")
     changes = diff_fields(t, data)
+    if incoming_cf is not None:
+        merged_cf = validate_and_merge(db, "test", incoming_cf, t.custom_fields, partial=True)
+        changes.extend(diff_custom_fields(db, "test", t.custom_fields, merged_cf))
+        data["custom_fields"] = merged_cf
     if category_ids is not None:
         old_cats = sorted(t.category_ids)
         new_cats = sorted(category_ids)

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel, field_validator
-from typing import Optional, List, Any
+from typing import Optional, List, Any, Dict
 
 
 class FolderOut(BaseModel):
@@ -37,8 +37,14 @@ class TestOut(BaseModel):
     source_ref: Optional[str] = None
     source_body: Optional[str] = None
     source_synced_at: Optional[str] = None
+    custom_fields: Dict[str, Any] = {}
 
     model_config = {"from_attributes": True}
+
+    @field_validator("custom_fields", mode="before")
+    @classmethod
+    def _cf_default(cls, v):
+        return v or {}
 
 
 class TestCreate(BaseModel):
@@ -55,6 +61,7 @@ class TestCreate(BaseModel):
     updated_at: Optional[str] = None
     last_run_at: Optional[str] = None
     duration: Optional[str] = None
+    custom_fields: Dict[str, Any] = {}
 
 
 class TestUpdate(BaseModel):
@@ -66,6 +73,7 @@ class TestUpdate(BaseModel):
     folder_id: Optional[str] = None
     project_id: Optional[str] = None
     category_ids: Optional[List[str]] = None
+    custom_fields: Optional[Dict[str, Any]] = None   # merged per-key; null value removes the key
 
 
 class RunCaseOut(BaseModel):
@@ -217,8 +225,14 @@ class DefectOut(BaseModel):
     external_provider: Optional[str] = None
     external_key: Optional[str] = None
     external_url: Optional[str] = None
+    custom_fields: Dict[str, Any] = {}
 
     model_config = {"from_attributes": True}
+
+    @field_validator("custom_fields", mode="before")
+    @classmethod
+    def _cf_default(cls, v):
+        return v or {}
 
 
 class DefectCreate(BaseModel):
@@ -227,6 +241,7 @@ class DefectCreate(BaseModel):
     description: Optional[str] = None
     test_id: Optional[str] = None
     run_id: Optional[str] = None
+    custom_fields: Dict[str, Any] = {}
 
 
 class DefectUpdate(BaseModel):
@@ -234,6 +249,7 @@ class DefectUpdate(BaseModel):
     status: Optional[str] = None
     severity: Optional[str] = None
     description: Optional[str] = None
+    custom_fields: Optional[Dict[str, Any]] = None   # merged per-key; null value removes the key
 
 
 class RequirementCoverage(BaseModel):
@@ -259,8 +275,14 @@ class RequirementOut(BaseModel):
     external_url: Optional[str] = None
     test_ids: List[str] = []
     coverage: RequirementCoverage = RequirementCoverage()
+    custom_fields: Dict[str, Any] = {}
 
     model_config = {"from_attributes": True}
+
+    @field_validator("custom_fields", mode="before")
+    @classmethod
+    def _cf_default(cls, v):
+        return v or {}
 
 
 class RequirementCreate(BaseModel):
@@ -271,6 +293,7 @@ class RequirementCreate(BaseModel):
     description: Optional[str] = None
     owner: Optional[str] = None
     test_ids: List[str] = []
+    custom_fields: Dict[str, Any] = {}
 
 
 class RequirementUpdate(BaseModel):
@@ -281,6 +304,43 @@ class RequirementUpdate(BaseModel):
     description: Optional[str] = None
     owner: Optional[str] = None
     test_ids: Optional[List[str]] = None
+    custom_fields: Optional[Dict[str, Any]] = None   # merged per-key; null value removes the key
+
+
+class CustomFieldDefOut(BaseModel):
+    id: int
+    entity_type: str
+    key: str
+    label: str
+    field_type: str
+    options: List[str] = []
+    required: bool = False
+    order: int = 0
+
+    model_config = {"from_attributes": True}
+
+    @field_validator("options", mode="before")
+    @classmethod
+    def _options_default(cls, v):
+        return v or []
+
+
+class CustomFieldDefCreate(BaseModel):
+    entity_type: str                   # test | defect | requirement
+    key: Optional[str] = None          # derived from label when omitted
+    label: str
+    field_type: str = "text"           # text | number | select | date | checkbox
+    options: List[str] = []
+    required: bool = False
+    order: int = 0
+
+
+class CustomFieldDefUpdate(BaseModel):
+    label: Optional[str] = None
+    field_type: Optional[str] = None
+    options: Optional[List[str]] = None
+    required: Optional[bool] = None
+    order: Optional[int] = None
 
 
 class CommentOut(BaseModel):

--- a/backend/tests/test_custom_fields.py
+++ b/backend/tests/test_custom_fields.py
@@ -1,0 +1,172 @@
+"""Custom field definitions (admin CRUD) + per-record values on tests,
+defects and requirements."""
+
+
+def _mk_def(client, **over):
+    payload = {
+        "entity_type": "defect",
+        "label": "Browser",
+        "field_type": "select",
+        "options": ["chrome", "firefox", "safari"],
+        **over,
+    }
+    return client.post("/api/custom-fields", json=payload)
+
+
+# ---------- definition CRUD ----------
+
+def test_create_and_list_defs(client):
+    r = _mk_def(client)
+    assert r.status_code == 201
+    body = r.json()
+    assert body["key"] == "browser"          # slug derived from label
+    assert body["entity_type"] == "defect"
+    assert body["options"] == ["chrome", "firefox", "safari"]
+
+    r = client.get("/api/custom-fields?entity_type=defect")
+    assert r.status_code == 200
+    assert [d["key"] for d in r.json()] == ["browser"]
+
+    # other entity type list is empty
+    assert client.get("/api/custom-fields?entity_type=test").json() == []
+
+
+def test_duplicate_key_409(client):
+    assert _mk_def(client).status_code == 201
+    assert _mk_def(client).status_code == 409
+
+
+def test_invalid_def_400(client):
+    assert _mk_def(client, entity_type="banana").status_code == 400
+    assert _mk_def(client, field_type="banana").status_code == 400
+    # select without options
+    assert _mk_def(client, label="Env", options=[]).status_code == 400
+    # bad explicit key
+    assert _mk_def(client, key="Not Valid!").status_code == 400
+
+
+def test_update_and_delete_def(client):
+    def_id = _mk_def(client).json()["id"]
+    r = client.patch(f"/api/custom-fields/{def_id}", json={"label": "Web browser", "required": True})
+    assert r.status_code == 200
+    assert r.json()["label"] == "Web browser"
+    assert r.json()["required"] is True
+
+    assert client.delete(f"/api/custom-fields/{def_id}").status_code == 204
+    assert client.get("/api/custom-fields").json() == []
+
+
+def test_def_write_requires_admin(auth_client):
+    tester = auth_client("tester")
+    r = tester.post("/api/custom-fields", json={"entity_type": "defect", "label": "X"})
+    assert r.status_code == 403
+    # read is allowed for any authenticated user
+    assert tester.get("/api/custom-fields").status_code == 200
+
+
+# ---------- values on records ----------
+
+def test_defect_create_with_custom_fields(client):
+    _mk_def(client)
+    r = client.post("/api/defects", json={"title": "Broken", "custom_fields": {"browser": "chrome"}})
+    assert r.status_code == 201
+    assert r.json()["custom_fields"] == {"browser": "chrome"}
+
+    got = client.get(f"/api/defects/{r.json()['id']}")
+    assert got.json()["custom_fields"] == {"browser": "chrome"}
+
+
+def test_defect_unknown_key_400(client):
+    _mk_def(client)
+    r = client.post("/api/defects", json={"title": "Broken", "custom_fields": {"nope": 1}})
+    assert r.status_code == 400
+    assert "nope" in r.json()["detail"]
+
+
+def test_select_value_must_match_options(client):
+    _mk_def(client)
+    r = client.post("/api/defects", json={"title": "Broken", "custom_fields": {"browser": "opera"}})
+    assert r.status_code == 400
+
+
+def test_required_field_enforced_on_create(client):
+    _mk_def(client, required=True)
+    r = client.post("/api/defects", json={"title": "Broken"})
+    assert r.status_code == 400
+    assert "browser" in r.json()["detail"]
+
+
+def test_patch_merges_and_clears(client):
+    _mk_def(client)
+    _mk_def(client, label="Repro rate", field_type="number", options=[])
+    d = client.post("/api/defects", json={"title": "Broken", "custom_fields": {"browser": "chrome"}}).json()
+
+    # merge: adding a second key keeps the first
+    r = client.patch(f"/api/defects/{d['id']}", json={"custom_fields": {"repro_rate": 80}})
+    assert r.status_code == 200
+    assert r.json()["custom_fields"] == {"browser": "chrome", "repro_rate": 80}
+
+    # null clears a key
+    r = client.patch(f"/api/defects/{d['id']}", json={"custom_fields": {"browser": None}})
+    assert r.json()["custom_fields"] == {"repro_rate": 80}
+
+    # patch without custom_fields leaves them alone
+    r = client.patch(f"/api/defects/{d['id']}", json={"status": "in_progress"})
+    assert r.json()["custom_fields"] == {"repro_rate": 80}
+
+
+def test_type_validation(client):
+    _mk_def(client, label="Repro rate", field_type="number", options=[])
+    _mk_def(client, label="Regression", field_type="checkbox", options=[])
+    _mk_def(client, label="Found on", field_type="date", options=[])
+
+    bad = [
+        {"repro_rate": "eighty"},
+        {"repro_rate": True},
+        {"regression": "yes"},
+        {"found_on": "15/07/2026"},
+    ]
+    for cf in bad:
+        r = client.post("/api/defects", json={"title": "x", "custom_fields": cf})
+        assert r.status_code == 400, cf
+
+    ok = {"repro_rate": 80.5, "regression": True, "found_on": "2026-07-15"}
+    r = client.post("/api/defects", json={"title": "x", "custom_fields": ok})
+    assert r.status_code == 201
+    assert r.json()["custom_fields"] == ok
+
+
+def test_test_create_and_update_custom_fields(client):
+    client.post("/api/custom-fields", json={"entity_type": "test", "label": "Component"})
+    r = client.post("/api/tests", json={"id": "TC-CF1", "title": "t", "custom_fields": {"component": "checkout"}})
+    assert r.status_code == 201
+    assert r.json()["custom_fields"] == {"component": "checkout"}
+
+    r = client.patch("/api/tests/TC-CF1", json={"custom_fields": {"component": "cart"}})
+    assert r.status_code == 200
+    assert r.json()["custom_fields"] == {"component": "cart"}
+
+    # change recorded in record history with the def's label
+    hist = client.get("/api/history/test/TC-CF1").json()
+    updated = [h for h in hist if h["action"] == "updated"]
+    assert any(c["field"] == "Component" and c["new"] == "cart"
+               for h in updated for c in h["changes"])
+
+
+def test_requirement_custom_fields_roundtrip(client):
+    client.post("/api/custom-fields", json={
+        "entity_type": "requirement", "label": "Release",
+        "field_type": "select", "options": ["v1", "v2"],
+    })
+    r = client.post("/api/requirements", json={"title": "Guest checkout", "custom_fields": {"release": "v2"}})
+    assert r.status_code == 201
+    req = r.json()
+    assert req["custom_fields"] == {"release": "v2"}
+
+    r = client.patch(f"/api/requirements/{req['id']}", json={"custom_fields": {"release": "v1"}})
+    assert r.status_code == 200
+    assert r.json()["custom_fields"] == {"release": "v1"}
+
+    # list endpoint carries the values too
+    lst = client.get("/api/requirements").json()
+    assert lst[0]["custom_fields"] == {"release": "v1"}

--- a/frontend/api.js
+++ b/frontend/api.js
@@ -1005,6 +1005,43 @@
       return new WebSocket(`${proto}://${location.host}/ws/notifications?token=${encodeURIComponent(token)}`);
     },
 
+    // Custom field definitions (admin-managed; values live on each record)
+    async getCustomFields(entityType) {
+      const qs = entityType ? `?entity_type=${encodeURIComponent(entityType)}` : "";
+      const res = await fetch(BASE + `/api/custom-fields${qs}`, { headers: authHeaders() });
+      if (!res.ok) throw new Error("Failed to load custom fields");
+      return res.json();
+    },
+
+    async createCustomField(payload) {
+      const res = await fetch(BASE + "/api/custom-fields", {
+        method: "POST", headers: authHeaders(), body: JSON.stringify(payload),
+      });
+      if (!res.ok) { const e = await res.json().catch(() => ({})); throw new Error(e.detail || "Create failed"); }
+      return res.json();
+    },
+
+    async updateCustomField(id, payload) {
+      const res = await fetch(BASE + `/api/custom-fields/${id}`, {
+        method: "PATCH", headers: authHeaders(), body: JSON.stringify(payload),
+      });
+      if (!res.ok) { const e = await res.json().catch(() => ({})); throw new Error(e.detail || "Update failed"); }
+      return res.json();
+    },
+
+    async deleteCustomField(id) {
+      const res = await fetch(BASE + `/api/custom-fields/${id}`, { method: "DELETE", headers: authHeaders() });
+      if (!res.ok && res.status !== 204) { const e = await res.json().catch(() => ({})); throw new Error(e.detail || "Delete failed"); }
+    },
+
+    async updateTest(id, payload) {
+      const res = await fetch(BASE + `/api/tests/${id}`, {
+        method: "PATCH", headers: authHeaders(), body: JSON.stringify(payload),
+      });
+      if (!res.ok) { const e = await res.json().catch(() => ({})); throw new Error(e.detail || "Update failed"); }
+      return res.json();
+    },
+
     async getAuditLog({ start_date, end_date, page = 1, page_size = 50 } = {}) {
       const params = new URLSearchParams();
       if (start_date) params.set("start_date", start_date);

--- a/frontend/components/custom-fields.jsx
+++ b/frontend/components/custom-fields.jsx
@@ -1,0 +1,268 @@
+// Custom fields — shared pieces for admin-defined extra fields on
+// tests / defects / requirements.
+//
+//   useCustomFieldDefs(entityType)                    → [defs, loading]
+//   <CustomFieldsInputs defs values onChange />       → form inputs (create/edit modals)
+//   <CustomFieldsDisplay defs values />               → read-only rows (detail views)
+//   <CustomFieldsAdmin />                             → admin manager (Admin page tab)
+//
+// Definitions come from GET /api/custom-fields; values ride on each record's
+// `custom_fields` object and are validated server-side.
+
+function useCustomFieldDefs(entityType) {
+  const [defs, setDefs] = useState([]);
+  const [loading, setLoading] = useState(true);
+  useEffect(() => {
+    let alive = true;
+    TH_API.getCustomFields(entityType)
+      .then(d => { if (alive) { setDefs(d); setLoading(false); } })
+      .catch(() => { if (alive) setLoading(false); });
+    return () => { alive = false; };
+  }, [entityType]);
+  return [defs, loading];
+}
+
+// One labelled input per definition. `values` is the record's custom_fields
+// object; onChange receives the updated object.
+function CustomFieldsInputs({ defs, values, onChange }) {
+  if (!defs || defs.length === 0) return null;
+  const set = (key, v) => onChange({ ...(values || {}), [key]: v });
+  const L = { fontSize:11, color:"var(--text-dim)", textTransform:"uppercase", letterSpacing:"0.06em", display:"block", marginBottom:4 };
+  return (
+    <>
+      {defs.map(d => {
+        const v = (values || {})[d.key];
+        return (
+          <div key={d.key}>
+            <label style={L}>{d.label}{d.required ? " *" : ""}</label>
+            {d.field_type === "select" ? (
+              <select className="input" style={{width:"100%"}} value={v ?? ""} onChange={e => set(d.key, e.target.value || null)}>
+                <option value="">— none —</option>
+                {(d.options || []).map(o => <option key={o} value={o}>{o}</option>)}
+              </select>
+            ) : d.field_type === "checkbox" ? (
+              <label style={{display:"flex", alignItems:"center", gap:8, cursor:"pointer", fontSize:12.5}}>
+                <input type="checkbox" checked={!!v} onChange={e => set(d.key, e.target.checked)} style={{accentColor:"var(--accent)"}} />
+                <span>{d.label}</span>
+              </label>
+            ) : d.field_type === "number" ? (
+              <input className="input" type="number" style={{width:"100%", boxSizing:"border-box"}} value={v ?? ""}
+                     onChange={e => set(d.key, e.target.value === "" ? null : Number(e.target.value))} />
+            ) : d.field_type === "date" ? (
+              <input className="input" type="date" style={{width:"100%", boxSizing:"border-box"}} value={v ?? ""}
+                     onChange={e => set(d.key, e.target.value || null)} />
+            ) : (
+              <input className="input" style={{width:"100%", boxSizing:"border-box"}} value={v ?? ""}
+                     onChange={e => set(d.key, e.target.value || null)} />
+            )}
+          </div>
+        );
+      })}
+    </>
+  );
+}
+
+function formatCustomFieldValue(def, v) {
+  if (v === undefined || v === null || v === "") return null;
+  if (def.field_type === "checkbox") return v ? "yes" : "no";
+  return String(v);
+}
+
+// Read-only label/value rows for detail panels. Renders nothing when the
+// record has no values for the given defs.
+function CustomFieldsDisplay({ defs, values }) {
+  const rows = (defs || [])
+    .map(d => ({ d, text: formatCustomFieldValue(d, (values || {})[d.key]) }))
+    .filter(r => r.text !== null);
+  if (rows.length === 0) return null;
+  return (
+    <>
+      {rows.map(({ d, text }) => (
+        <div key={d.key} style={{display:"flex", alignItems:"center", gap:10}}>
+          <div style={{color:"var(--text-dim)", fontSize:11, textTransform:"uppercase", letterSpacing:"0.06em", width:120, flexShrink:0}}>{d.label}</div>
+          <div style={{flex:1, minWidth:0}}>{text}</div>
+        </div>
+      ))}
+    </>
+  );
+}
+
+// ---- Admin manager (Admin page → Custom fields tab) ------------------------
+
+const CF_ENTITY_TYPES = [
+  { id: "test", label: "Tests" },
+  { id: "defect", label: "Defects" },
+  { id: "requirement", label: "Requirements" },
+];
+const CF_FIELD_TYPES = ["text", "number", "select", "date", "checkbox"];
+
+function CustomFieldsAdmin() {
+  const [entityType, setEntityType] = useState("test");
+  const [defs, setDefs] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [err, setErr] = useState(null);
+  const [editing, setEditing] = useState(null);   // def object, or {} for new
+
+  const load = () => {
+    setLoading(true);
+    TH_API.getCustomFields(entityType)
+      .then(d => { setDefs(d); setErr(null); })
+      .catch(e => setErr(e.message))
+      .finally(() => setLoading(false));
+  };
+  useEffect(load, [entityType]);
+
+  const handleDelete = async (d) => {
+    if (!window.confirm(`Delete field "${d.label}"? Existing values stay stored but are no longer shown.`)) return;
+    try {
+      await TH_API.deleteCustomField(d.id);
+      setDefs(prev => prev.filter(x => x.id !== d.id));
+    } catch (e) { alert(e.message); }
+  };
+
+  return (
+    <div>
+      <div style={{display:"flex", alignItems:"center", gap:8, marginBottom:16}}>
+        <h2 style={{margin:0, fontSize:18, fontWeight:600}}>Custom fields</h2>
+        <div className="spacer" style={{flex:1}} />
+        <select className="input" style={{width:150}} value={entityType} onChange={e => setEntityType(e.target.value)}>
+          {CF_ENTITY_TYPES.map(t => <option key={t.id} value={t.id}>{t.label}</option>)}
+        </select>
+        <button className="btn accent sm" onClick={() => setEditing({})}><Icon name="plus" /> New field</button>
+      </div>
+      <p style={{fontSize:12.5, color:"var(--text-muted)", margin:"0 0 16px"}}>
+        Extra fields shown on every {entityType} form. Values are stored per record and validated by the server.
+      </p>
+
+      {err && <div style={{color:"var(--fail)", fontSize:12, marginBottom:10}}>{err}</div>}
+      {loading ? (
+        <div className="mono dim" style={{padding:24}}>Loading…</div>
+      ) : defs.length === 0 ? (
+        <div className="mono dim" style={{padding:24}}>No custom fields for {entityType}s yet.</div>
+      ) : (
+        <table className="table">
+          <thead>
+            <tr>
+              <th>Label</th>
+              <th style={{width:140}}>Key</th>
+              <th style={{width:100}}>Type</th>
+              <th>Options</th>
+              <th style={{width:80}}>Required</th>
+              <th style={{width:64}}></th>
+            </tr>
+          </thead>
+          <tbody>
+            {defs.map(d => (
+              <tr key={d.id}>
+                <td style={{fontWeight:500}}>{d.label}</td>
+                <td className="mono" style={{fontSize:11.5}}>{d.key}</td>
+                <td><span className="tag">{d.field_type}</span></td>
+                <td style={{fontSize:12}}>{(d.options || []).join(", ") || <span className="dim">—</span>}</td>
+                <td>{d.required ? "yes" : <span className="dim">no</span>}</td>
+                <td>
+                  <div style={{display:"flex", gap:2}}>
+                    <button className="btn ghost sm" style={{padding:"2px 6px"}} title="Edit" onClick={() => setEditing(d)}><Icon name="settings" /></button>
+                    <button className="btn ghost sm" style={{color:"var(--fail)", padding:"2px 6px"}} title="Delete" onClick={() => handleDelete(d)}><Icon name="x" /></button>
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+
+      {editing && (
+        <CustomFieldDefModal
+          def={editing.id ? editing : null}
+          entityType={entityType}
+          onClose={() => setEditing(null)}
+          onSaved={(d, isNew) => {
+            setDefs(prev => isNew ? [...prev, d] : prev.map(x => x.id === d.id ? d : x));
+            setEditing(null);
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+function CustomFieldDefModal({ def, entityType, onClose, onSaved }) {
+  const isNew = !def;
+  const [form, setForm] = useState({
+    label: def?.label || "",
+    field_type: def?.field_type || "text",
+    options: (def?.options || []).join(", "),
+    required: def?.required || false,
+  });
+  const [saving, setSaving] = useState(false);
+  const [err, setErr] = useState(null);
+
+  const save = async () => {
+    if (!form.label.trim()) return;
+    setSaving(true); setErr(null);
+    const options = form.field_type === "select"
+      ? form.options.split(",").map(o => o.trim()).filter(Boolean)
+      : [];
+    try {
+      const payload = { label: form.label.trim(), field_type: form.field_type, options, required: form.required };
+      const d = isNew
+        ? await TH_API.createCustomField({ ...payload, entity_type: entityType })
+        : await TH_API.updateCustomField(def.id, payload);
+      onSaved(d, isNew);
+    } catch (e) { setErr(e.message); }
+    setSaving(false);
+  };
+
+  const L = { fontSize:11, color:"var(--text-dim)", textTransform:"uppercase", letterSpacing:"0.06em", display:"block", marginBottom:4 };
+
+  return (
+    <div style={{position:"fixed", inset:0, background:"rgba(0,0,0,0.55)", zIndex:1000, display:"flex", alignItems:"center", justifyContent:"center"}} onClick={onClose}>
+      <div style={{background:"var(--bg-2)", border:"1px solid var(--border)", borderRadius:8, padding:24, width:440}} onClick={e => e.stopPropagation()}>
+        <h2 style={{fontSize:15, fontWeight:600, margin:"0 0 16px"}}>
+          {isNew ? `New ${entityType} field` : `Edit "${def.label}"`}
+        </h2>
+        <div style={{display:"flex", flexDirection:"column", gap:10}}>
+          <div>
+            <label style={L}>Label</label>
+            <input className="input" style={{width:"100%", boxSizing:"border-box"}} value={form.label}
+                   placeholder="e.g. Browser" autoFocus
+                   onChange={e => setForm(f => ({...f, label: e.target.value}))} />
+            {isNew && <div style={{fontSize:11, color:"var(--text-dim)", marginTop:3}}>Key is derived automatically (lowercase, underscores).</div>}
+          </div>
+          <div>
+            <label style={L}>Type</label>
+            <select className="input" style={{width:"100%"}} value={form.field_type}
+                    onChange={e => setForm(f => ({...f, field_type: e.target.value}))}>
+              {CF_FIELD_TYPES.map(t => <option key={t} value={t}>{t}</option>)}
+            </select>
+          </div>
+          {form.field_type === "select" && (
+            <div>
+              <label style={L}>Options (comma-separated)</label>
+              <input className="input" style={{width:"100%", boxSizing:"border-box"}} value={form.options}
+                     placeholder="chrome, firefox, safari"
+                     onChange={e => setForm(f => ({...f, options: e.target.value}))} />
+            </div>
+          )}
+          <label style={{display:"flex", alignItems:"center", gap:8, cursor:"pointer", fontSize:12.5}}>
+            <input type="checkbox" checked={form.required} style={{accentColor:"var(--accent)"}}
+                   onChange={e => setForm(f => ({...f, required: e.target.checked}))} />
+            <span>Required on create</span>
+          </label>
+        </div>
+        {err && <div style={{color:"var(--fail)", fontSize:12, marginTop:10}}>{err}</div>}
+        <div style={{display:"flex", gap:8, justifyContent:"flex-end", marginTop:20}}>
+          <button className="btn" onClick={onClose}>Cancel</button>
+          <button className="btn accent" onClick={save} disabled={saving || !form.label.trim()}>
+            {saving ? "Saving…" : (isNew ? "Create" : "Save")}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+window.useCustomFieldDefs = useCustomFieldDefs;
+window.CustomFieldsInputs = CustomFieldsInputs;
+window.CustomFieldsDisplay = CustomFieldsDisplay;
+window.CustomFieldsAdmin = CustomFieldsAdmin;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -37,6 +37,7 @@
 <script src="components/app-shell.js"></script>
 <script src="components/hooks.js"></script>
 <script src="components/change-history.js"></script>
+<script src="components/custom-fields.js"></script>
 <script src="views/view-overview.js"></script>
 <script src="views/view-library.js"></script>
 <script src="views/view-test-detail.js"></script>

--- a/frontend/views/view-admin.jsx
+++ b/frontend/views/view-admin.jsx
@@ -16,6 +16,7 @@ function AdminPage({ currentUser, onNav }) {
 
   const ADMIN_TABS = [
     { id: "users",     label: t("admin.users") || "User Management" },
+    { id: "custom-fields", label: "Custom Fields" },
     ...(window.can && window.can(currentUser, "manage") ? [{ id: "audit-log", label: "Audit Log" }] : []),
   ];
 
@@ -170,6 +171,7 @@ function AdminPage({ currentUser, onNav }) {
           )}
         </div>
       )}
+      {tab === "custom-fields" && <CustomFieldsAdmin />}
       {tab === "audit-log" && <AuditLogTab currentUser={currentUser} />}
     </div>
   );

--- a/frontend/views/view-defects.jsx
+++ b/frontend/views/view-defects.jsx
@@ -7,9 +7,11 @@ function Defects({ focusId }) {
   const [filterStatus, setFilterStatus] = useState("all");
   const [filterSeverity, setFilterSeverity] = useState("all");
   const [showCreate, setShowCreate] = useState(false);
+  const [editingDefect, setEditingDefect] = useState(null);
   const [deleteConfirmId, setDeleteConfirmId] = useState(null);
   const [historyId, setHistoryId] = useState(null);
   const [runs, setRuns] = useState([]);
+  const [cfDefs] = useCustomFieldDefs("defect");
 
   const load = () => {
     setLoading(true);
@@ -165,6 +167,15 @@ function Defects({ focusId }) {
                         </div>
                       )}
                       {d.created_by && <div style={{fontSize:10.5, color:"var(--text-dim)", marginTop:2}}>Filed by {d.created_by}</div>}
+                      {cfDefs.length > 0 && d.custom_fields && Object.keys(d.custom_fields).length > 0 && (
+                        <div style={{display:"flex", gap:4, flexWrap:"wrap", marginTop:3}}>
+                          {cfDefs.filter(f => d.custom_fields[f.key] !== undefined && d.custom_fields[f.key] !== null && d.custom_fields[f.key] !== "").map(f => (
+                            <span key={f.key} className="tag" style={{fontSize:10}}>
+                              {f.label}: {f.field_type === "checkbox" ? (d.custom_fields[f.key] ? "yes" : "no") : String(d.custom_fields[f.key])}
+                            </span>
+                          ))}
+                        </div>
+                      )}
                     </td>
                     <td>
                       <select
@@ -199,6 +210,12 @@ function Defects({ focusId }) {
                       <button
                         className="btn ghost sm"
                         style={{padding:"2px 6px"}}
+                        onClick={() => setEditingDefect(d)}
+                        title="Edit"
+                      ><Icon name="settings" /></button>
+                      <button
+                        className="btn ghost sm"
+                        style={{padding:"2px 6px"}}
                         onClick={() => setHistoryId(d.id)}
                         title="Change history"
                       ><Icon name="clock" /></button>
@@ -222,6 +239,14 @@ function Defects({ focusId }) {
           runs={runs}
           onClose={() => setShowCreate(false)}
           onCreated={(d) => { setDefects(prev => [d, ...prev]); setShowCreate(false); }}
+        />
+      )}
+
+      {editingDefect && (
+        <EditDefectModal
+          defect={editingDefect}
+          onClose={() => setEditingDefect(null)}
+          onSaved={(d) => { setDefects(prev => prev.map(x => x.id === d.id ? d : x)); setEditingDefect(null); }}
         />
       )}
 
@@ -256,11 +281,15 @@ function Defects({ focusId }) {
 
 function CreateDefectModal({ runs, onClose, onCreated }) {
   const [form, setForm] = useState({ title: "", severity: "med", run_id: "", test_id: "", description: "" });
+  const [customFields, setCustomFields] = useState({});
+  const [cfDefs] = useCustomFieldDefs("defect");
   const [saving, setSaving] = useState(false);
+  const [err, setErr] = useState(null);
 
   const handleCreate = async () => {
     if (!form.title.trim()) return;
     setSaving(true);
+    setErr(null);
     try {
       const d = await TH_API.createDefect({
         title: form.title.trim(),
@@ -268,9 +297,10 @@ function CreateDefectModal({ runs, onClose, onCreated }) {
         description: form.description.trim() || null,
         test_id: form.test_id.trim() || null,
         run_id: form.run_id || null,
+        custom_fields: customFields,
       });
       onCreated(d);
-    } catch (e) {}
+    } catch (e) { setErr(e.message); }
     setSaving(false);
   };
 
@@ -309,11 +339,91 @@ function CreateDefectModal({ runs, onClose, onCreated }) {
               {runs.map(r => <option key={r.id} value={r.id}>{r.id} · {r.name.slice(0,40)}</option>)}
             </select>
           </div>
+          <CustomFieldsInputs defs={cfDefs} values={customFields} onChange={setCustomFields} />
         </div>
+        {err && <div style={{color:"var(--fail)", fontSize:12, marginTop:10}}>{err}</div>}
         <div style={{display:"flex", gap:8, justifyContent:"flex-end", marginTop:20}}>
           <button className="btn" onClick={onClose}>Cancel</button>
           <button className="btn accent" onClick={handleCreate} disabled={saving || !form.title.trim()}>
             {saving ? "Creating…" : "Create"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function EditDefectModal({ defect, onClose, onSaved }) {
+  const [form, setForm] = useState({
+    title: defect.title || "",
+    severity: defect.severity || "med",
+    status: defect.status || "open",
+    description: defect.description || "",
+  });
+  const [customFields, setCustomFields] = useState(defect.custom_fields || {});
+  const [cfDefs] = useCustomFieldDefs("defect");
+  const [saving, setSaving] = useState(false);
+  const [err, setErr] = useState(null);
+
+  const save = async () => {
+    if (!form.title.trim()) return;
+    setSaving(true);
+    setErr(null);
+    try {
+      const d = await TH_API.updateDefect(defect.id, {
+        title: form.title.trim(),
+        severity: form.severity,
+        status: form.status,
+        description: form.description.trim() || null,
+        custom_fields: customFields,
+      });
+      onSaved(d);
+    } catch (e) { setErr(e.message); }
+    setSaving(false);
+  };
+
+  const L = { fontSize:11, color:"var(--text-dim)", textTransform:"uppercase", letterSpacing:"0.06em", display:"block", marginBottom:4 };
+
+  return (
+    <div style={{position:"fixed", inset:0, background:"rgba(0,0,0,0.55)", zIndex:1000, display:"flex", alignItems:"center", justifyContent:"center"}} onClick={onClose}>
+      <div style={{background:"var(--bg-2)", border:"1px solid var(--border)", borderRadius:8, padding:24, width:500, maxHeight:"85vh", overflowY:"auto"}} onClick={e => e.stopPropagation()}>
+        <h2 style={{fontSize:15, fontWeight:600, margin:"0 0 16px"}}>Edit {defect.id}</h2>
+        <div style={{display:"flex", flexDirection:"column", gap:10}}>
+          <div>
+            <label style={L}>Title</label>
+            <input className="input" style={{width:"100%", boxSizing:"border-box"}} value={form.title} onChange={e => setForm(f => ({...f, title: e.target.value}))} autoFocus />
+          </div>
+          <div>
+            <label style={L}>Description</label>
+            <textarea className="textarea" style={{width:"100%", boxSizing:"border-box", minHeight:60}} value={form.description} onChange={e => setForm(f => ({...f, description: e.target.value}))} />
+          </div>
+          <div style={{display:"grid", gridTemplateColumns:"1fr 1fr", gap:10}}>
+            <div>
+              <label style={L}>Severity</label>
+              <select className="input" value={form.severity} onChange={e => setForm(f => ({...f, severity: e.target.value}))}>
+                <option value="critical">Critical</option>
+                <option value="high">High</option>
+                <option value="med">Medium</option>
+                <option value="low">Low</option>
+              </select>
+            </div>
+            <div>
+              <label style={L}>Status</label>
+              <select className="input" value={form.status} onChange={e => setForm(f => ({...f, status: e.target.value}))}>
+                <option value="open">Open</option>
+                <option value="in_progress">In progress</option>
+                <option value="resolved">Resolved</option>
+                <option value="closed">Closed</option>
+              </select>
+            </div>
+          </div>
+          <CustomFieldsInputs defs={cfDefs} values={customFields} onChange={setCustomFields} />
+        </div>
+        {err && <div style={{color:"var(--fail)", fontSize:12, marginTop:10}}>{err}</div>}
+        <div style={{display:"flex", gap:8, justifyContent:"flex-end", marginTop:20}}>
+          <button className="btn" onClick={onClose}>Cancel</button>
+          <button className="btn accent" onClick={save} disabled={saving || !form.title.trim()}>
+            {saving ? "Saving…" : "Save"}
           </button>
         </div>
       </div>

--- a/frontend/views/view-library.jsx
+++ b/frontend/views/view-library.jsx
@@ -546,6 +546,8 @@ function NewTestModal({ folders, defaultFolderId, onClose, onCreate }) {
   const [form, setForm] = useState({
     id: "", title: "", folder_id: defaultFolderId || "", type: "manual", priority: "med", owner: "", tags: ""
   });
+  const [customFields, setCustomFields] = useState({});
+  const [cfDefs] = useCustomFieldDefs("test");
   const [saving, setSaving] = useState(false);
   const [err, setErr] = useState(null);
 
@@ -566,6 +568,7 @@ function NewTestModal({ folders, defaultFolderId, onClose, onCreate }) {
         tags: form.tags.split(",").map(t => t.trim()).filter(Boolean),
         auto: form.type === "automated",
         status: "pending",
+        custom_fields: customFields,
       };
       const res = await fetch("/api/tests", {
         method: "POST",
@@ -626,6 +629,7 @@ function NewTestModal({ folders, defaultFolderId, onClose, onCreate }) {
           <FormField label="Tags" hint="comma-separated">
             <input className="input" value={form.tags} onChange={e => setF("tags", e.target.value)} placeholder="smoke, payment, p0" />
           </FormField>
+          <CustomFieldsInputs defs={cfDefs} values={customFields} onChange={setCustomFields} />
         </div>
 
         {err && <div style={{color:"var(--fail)", fontSize:12, marginTop:12}}>{err}</div>}

--- a/frontend/views/view-requirements.jsx
+++ b/frontend/views/view-requirements.jsx
@@ -272,11 +272,15 @@ function RequirementModal({ requirement, onClose, onSaved }) {
     description: requirement?.description || "",
     test_ids: requirement?.test_ids || [],
   });
+  const [customFields, setCustomFields] = useState(requirement?.custom_fields || {});
+  const [cfDefs] = useCustomFieldDefs("requirement");
   const [saving, setSaving] = useState(false);
+  const [err, setErr] = useState(null);
 
   const save = async () => {
     if (!form.title.trim()) return;
     setSaving(true);
+    setErr(null);
     try {
       const payload = {
         title: form.title.trim(),
@@ -286,12 +290,13 @@ function RequirementModal({ requirement, onClose, onSaved }) {
         owner: form.owner.trim() || null,
         description: form.description.trim() || null,
         test_ids: form.test_ids,
+        custom_fields: customFields,
       };
       const r = isNew
         ? await TH_API.createRequirement(payload)
         : await TH_API.updateRequirement(requirement.id, payload);
       onSaved(r, isNew);
-    } catch (e) {}
+    } catch (e) { setErr(e.message); }
     setSaving(false);
   };
 
@@ -342,11 +347,13 @@ function RequirementModal({ requirement, onClose, onSaved }) {
             <label style={L}>Description (optional)</label>
             <textarea className="textarea" style={{width:"100%", boxSizing:"border-box", minHeight:60}} value={form.description} onChange={e => setForm(f => ({...f, description: e.target.value}))} />
           </div>
+          <CustomFieldsInputs defs={cfDefs} values={customFields} onChange={setCustomFields} />
           <div>
             <label style={L}>Linked tests</label>
             <TestPicker selected={form.test_ids} onChange={ids => setForm(f => ({...f, test_ids: ids}))} />
           </div>
         </div>
+        {err && <div style={{color:"var(--fail)", fontSize:12, marginTop:10}}>{err}</div>}
         {!isNew && (
           <div style={{marginTop:18, borderTop:"1px solid var(--border)", paddingTop:6}}>
             <label style={L}>Change history</label>

--- a/frontend/views/view-test-detail.jsx
+++ b/frontend/views/view-test-detail.jsx
@@ -143,7 +143,7 @@ function TestDetail({ testId, onBack, currentUser }) {
       </div>
 
       <div style={{overflowY:"auto", flex:1}}>
-        {tab === "definition" && <DefinitionTab test={test} currentUser={currentUser} />}
+        {tab === "definition" && <DefinitionTab test={test} currentUser={currentUser} onTestPatch={patch => setTest(t => ({...t, ...patch}))} />}
         {tab === "history" && <HistoryTab test={test} />}
         {tab === "defects" && <DefectsTab test={test} currentUser={currentUser} />}
         {tab === "requirements" && <RequirementsTab test={test} currentUser={currentUser} onCountChange={setReqCount} />}
@@ -168,7 +168,7 @@ function TestDetail({ testId, onBack, currentUser }) {
   );
 }
 
-function DefinitionTab({ test, currentUser }) {
+function DefinitionTab({ test, currentUser, onTestPatch }) {
   const [steps, setSteps] = React.useState([]);
   const [loading, setLoading] = React.useState(true);
   const [saving, setSaving] = React.useState(false);
@@ -322,7 +322,7 @@ function DefinitionTab({ test, currentUser }) {
 
         {/* YAML source — rendered only when this test is synced from git */}
         {test.source_path && <YamlSourceCard test={test}
-          onPushed={patch => setTest(t => ({...t, ...patch}))} />}
+          onPushed={patch => onTestPatch && onTestPatch(patch)} />}
       </div>
 
       {/* Side column — keep unchanged from original */}
@@ -343,6 +343,49 @@ function DefinitionTab({ test, currentUser }) {
             } />
           </div>
         </div>
+        <TestCustomFieldsCard test={test} />
+      </div>
+    </div>
+  );
+}
+
+// Editable custom fields (admin-defined) for one test. Hidden when no
+// definitions exist for tests. Owns its values state — the parent's copy of
+// test.custom_fields is not re-read after mount.
+function TestCustomFieldsCard({ test }) {
+  const [defs] = useCustomFieldDefs("test");
+  const [values, setValues] = useState(test.custom_fields || {});
+  const [dirty, setDirty] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [err, setErr] = useState(null);
+
+  useEffect(() => { setValues(test.custom_fields || {}); setDirty(false); }, [test.id]);
+
+  if (!defs || defs.length === 0) return null;
+
+  const save = async () => {
+    setSaving(true); setErr(null);
+    try {
+      const updated = await TH_API.updateTest(test.id, { custom_fields: values });
+      setValues(updated.custom_fields || {});
+      setDirty(false);
+    } catch (e) { setErr(e.message); }
+    setSaving(false);
+  };
+
+  return (
+    <div className="card">
+      <div className="card-h"><div className="card-title">Custom fields</div></div>
+      <div className="card-b" style={{display:"flex", flexDirection:"column", gap:10, fontSize:12}}>
+        <CustomFieldsInputs defs={defs} values={values} onChange={v => { setValues(v); setDirty(true); }} />
+        {err && <div style={{color:"var(--fail)", fontSize:12}}>{err}</div>}
+        {dirty && (
+          <div style={{display:"flex", justifyContent:"flex-end"}}>
+            <button className="btn accent sm" onClick={save} disabled={saving}>
+              {saving ? "Saving…" : "Save"}
+            </button>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/migrations/versions/d4f8a1c26e93_custom_fields.py
+++ b/migrations/versions/d4f8a1c26e93_custom_fields.py
@@ -1,0 +1,42 @@
+"""custom field definitions + custom_fields JSON column on tests/defects/requirements
+
+Revision ID: d4f8a1c26e93
+Revises: c5d9f3a2b8e1
+Create Date: 2026-07-15
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'd4f8a1c26e93'
+down_revision = 'c5d9f3a2b8e1'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'custom_field_defs',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('entity_type', sa.String(length=32), nullable=False),
+        sa.Column('key', sa.String(length=64), nullable=False),
+        sa.Column('label', sa.String(length=255), nullable=False),
+        sa.Column('field_type', sa.String(length=16), nullable=False),
+        sa.Column('options', sa.JSON(), nullable=True),
+        sa.Column('required', sa.Boolean(), nullable=True),
+        sa.Column('order', sa.Integer(), nullable=True),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('entity_type', 'key', name='uq_custom_field_entity_key'),
+    )
+    op.add_column('tests', sa.Column('custom_fields', sa.JSON(), nullable=True))
+    op.add_column('defects', sa.Column('custom_fields', sa.JSON(), nullable=True))
+    op.add_column('requirements', sa.Column('custom_fields', sa.JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('requirements', 'custom_fields')
+    op.drop_column('defects', 'custom_fields')
+    op.drop_column('tests', 'custom_fields')
+    op.drop_table('custom_field_defs')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thorotest",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "Source-available test management platform. Organize, run, and track tests across manual and automated suites — one timeline for both.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## What

Admins can define extra fields for tests, defects and requirements (Admin → Custom Fields tab); the fields then appear on every create/edit form for that entity and values are stored per record.

- Field types: `text`, `number`, `select` (with options), `date`, `checkbox`, plus a required-on-create flag. Key is auto-derived from the label.
- New `custom_field_defs` table + `custom_fields` JSON column on tests/defects/requirements (Alembic migration `d4f8a1c26e93`).
- `backend/routers/custom_fields.py`: definition CRUD (admin-only writes) and `validate_and_merge()` used by the three entity routers — unknown keys 400, type/option validation, per-key merge on PATCH, `null` clears a key, required fields enforced on create and protected from clearing.
- Value changes are logged in per-record change history under the field's label.

## UI

- Admin → **Custom Fields** tab: manage definitions per entity type.
- Fields render in the new-test, new-defect and new/edit-requirement modals, as an editable card on test detail, and as chips in the defect table.
- New **EditDefectModal** (title, description, severity, status + custom fields) — defects previously had no edit UI at all.
- Also fixes a latent `setTest is not defined` crash in `DefinitionTab`'s push-to-git callback.

## Testing

- 12 new backend tests (`backend/tests/test_custom_fields.py`); full suite 651 passed, 1 skipped.
- Migration smoke-tested via `backend.seed` on a fresh DB.
- Playwright end-to-end drive against a seeded instance: admin tab, def creation, all three forms, defect edit, persistence after reload — 18/18 checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)