### PR TITLE
ci: auto-deploy releases to the demo VPS

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -1,0 +1,63 @@
+name: Deploy demo
+
+# Deploys a release to the demo VPS. Fires when a version tag is pushed or a
+# GitHub release is published; can also be run by hand (workflow_dispatch)
+# against any tag/branch.
+#
+# Required repository secrets (see DEPLOY.local.md for VPS-side setup):
+#   DEMO_SSH_HOST   VPS hostname or IP
+#   DEMO_SSH_USER   SSH user owning /opt/thorotest-demo
+#   DEMO_SSH_KEY    private key (ed25519) authorized on the VPS
+#   DEMO_SSH_PORT   optional, defaults to 22
+
+on:
+  push:
+    tags: ['v*.*.*']
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Tag or branch to deploy (defaults to the triggering ref)'
+        required: false
+
+# One deploy at a time; a queued deploy waits instead of clobbering the
+# in-flight one mid-restart.
+concurrency:
+  group: deploy-demo
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy to demo VPS
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up SSH
+        env:
+          SSH_KEY: ${{ secrets.DEMO_SSH_KEY }}
+          SSH_HOST: ${{ secrets.DEMO_SSH_HOST }}
+          SSH_PORT: ${{ secrets.DEMO_SSH_PORT || '22' }}
+        run: |
+          mkdir -p ~/.ssh
+          printf '%s\n' "$SSH_KEY" > ~/.ssh/id_deploy
+          chmod 600 ~/.ssh/id_deploy
+          ssh-keyscan -p "$SSH_PORT" -H "$SSH_HOST" >> ~/.ssh/known_hosts 2>/dev/null
+
+      - name: Deploy
+        env:
+          SSH_HOST: ${{ secrets.DEMO_SSH_HOST }}
+          SSH_USER: ${{ secrets.DEMO_SSH_USER }}
+          SSH_PORT: ${{ secrets.DEMO_SSH_PORT || '22' }}
+          REF: ${{ github.event.inputs.ref || github.ref_name }}
+        run: |
+          # refuse refs with shell metacharacters — REF lands on a remote command line
+          [[ "$REF" =~ ^[A-Za-z0-9._/-]+$ ]] || { echo "invalid ref: $REF"; exit 1; }
+          echo "Deploying ref: $REF"
+          ssh -i ~/.ssh/id_deploy -p "$SSH_PORT" "$SSH_USER@$SSH_HOST" \
+            REF="$REF" 'bash -s' <<'REMOTE'
+          set -euo pipefail
+          cd /opt/thorotest-demo
+          git fetch origin --tags --force
+          git reset --hard "$REF"
+          ./scripts/deploy-demo.sh
+          REMOTE

--- a/scripts/deploy-demo.sh
+++ b/scripts/deploy-demo.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Demo-VPS deploy step, invoked by .github/workflows/deploy-demo.yml AFTER
+# the checkout has been reset to the target tag/branch — so this script always
+# runs at the version being deployed.
+#
+# VPS assumptions (one-time setup, see DEPLOY.local.md):
+#   - repo checkout at /opt/thorotest-demo with a ./venv virtualenv
+#   - systemd unit `thorotest-demo` (uvicorn on 127.0.0.1:8001)
+#   - deploy user can `sudo systemctl restart thorotest-demo` without password
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+echo "[deploy] db backup..."
+if [ -f testhub.db ]; then
+  cp testhub.db "testhub.db.bak.$(date +%Y%m%d-%H%M%S)"
+  # keep the 5 most recent backups
+  ls -t testhub.db.bak.* 2>/dev/null | tail -n +6 | xargs -r rm --
+fi
+
+echo "[deploy] python deps..."
+./venv/bin/pip install -q -r requirements.txt
+
+echo "[deploy] frontend build..."
+npm install --no-audit --no-fund --silent
+npm run build
+
+echo "[deploy] restart..."
+sudo systemctl restart thorotest-demo
+sleep 3
+
+echo "[deploy] verify..."
+systemctl is-active --quiet thorotest-demo || {
+  journalctl -u thorotest-demo -n 40 --no-pager
+  exit 1
+}
+# /health checks DB connectivity too (Alembic migrations ran during boot)
+curl -sf --max-time 10 http://127.0.0.1:8001/health >/dev/null || {
+  journalctl -u thorotest-demo -n 40 --no-pager
+  exit 1
+}
+echo "[deploy] OK — now at $(git rev-parse --short HEAD) ($(git describe --tags --always))"


### PR DESCRIPTION
## What

New `Deploy demo` workflow: pushing a `v*.*.*` tag or publishing a GitHub release automatically deploys that ref to the demo VPS. Manual runs supported via workflow_dispatch with an optional ref.

Flow: SSH into the VPS → `git fetch --tags && git reset --hard <ref>` → run `scripts/deploy-demo.sh` (checked out at the deployed version): pip deps, `npm run build`, `systemctl restart thorotest-demo`, `/health` check, SQLite backup with 5-copy rotation. On failure the job prints the last 40 journal lines.

Safety details:
- `concurrency: deploy-demo` — one deploy at a time, queued not cancelled.
- Ref validated against `^[A-Za-z0-9._/-]+$` before hitting the remote command line.
- Alembic migrations apply automatically at service boot (existing behavior).

## Setup required before first use

Repo secrets: `DEMO_SSH_HOST`, `DEMO_SSH_USER`, `DEMO_SSH_KEY` (+ optional `DEMO_SSH_PORT`). VPS: dedicated ed25519 key in authorized_keys + passwordless sudo for `systemctl restart thorotest-demo`. Step-by-step commands are in the local runbook (DEPLOY.local.md, not committed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)