### PR TITLE
feat(demo): corner ribbon overlay when DEMO_MODE is on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ This file is the single source of truth for the in-app About page
 (`GET /api/about` parses it), so keep the structure: one `## [x.y.z] - YYYY-MM-DD`
 heading per release, `### <Group>` subsections, `-` bullets.
 
+## [Unreleased]
+
+### Added
+- "Demo" corner ribbon overlay when the instance runs with `DEMO_MODE=1` —
+  always visible (login included), purely visual, never intercepts clicks.
+  Backed by the new public `GET /api/config` bootstrap-flags endpoint.
+
 ## [1.9.0] - 2026-07-16
 
 ### Added

--- a/backend/main.py
+++ b/backend/main.py
@@ -232,6 +232,18 @@ app.add_middleware(
 _STARTED_AT = time.monotonic()
 
 
+@app.get("/api/config")
+async def public_config():
+    """Public UI bootstrap flags.
+
+    Deliberately unauthenticated — the login screen needs them (e.g. the demo
+    ribbon) — and deliberately minimal: booleans only, no version, no secrets.
+    """
+    from .ws_manager import DEMO_MODE  # read at call time so tests can patch it
+
+    return {"demo_mode": DEMO_MODE}
+
+
 @app.get("/health")
 async def health():
     """Liveness/readiness probe: unauthenticated, checks DB connectivity.

--- a/backend/tests/test_demo_mode.py
+++ b/backend/tests/test_demo_mode.py
@@ -54,3 +54,35 @@ def test_demo_mode_env_parsing(monkeypatch):
     # Restore module state for other tests
     monkeypatch.delenv("DEMO_MODE", raising=False)
     importlib.reload(ws_manager)
+
+
+# ── /api/config — public UI bootstrap flags ─────────────────────
+
+def test_config_demo_mode_off_by_default(client, monkeypatch):
+    monkeypatch.setattr(ws_manager, "DEMO_MODE", False)
+    r = client.get("/api/config")
+    assert r.status_code == 200
+    assert r.json() == {"demo_mode": False}
+
+
+def test_config_demo_mode_on(client, monkeypatch):
+    monkeypatch.setattr(ws_manager, "DEMO_MODE", True)
+    assert client.get("/api/config").json() == {"demo_mode": True}
+
+
+def test_config_is_public_and_minimal(db, monkeypatch):
+    """No auth required (login screen needs it), and nothing but the flag."""
+    from fastapi.testclient import TestClient
+    from backend.main import app
+    from backend.db import get_db
+
+    monkeypatch.setattr(ws_manager, "DEMO_MODE", True)
+
+    def override():
+        yield db
+    app.dependency_overrides[get_db] = override
+    with TestClient(app) as c:
+        r = c.get("/api/config")
+    app.dependency_overrides.clear()
+    assert r.status_code == 200
+    assert set(r.json().keys()) == {"demo_mode"}

--- a/frontend/app.jsx
+++ b/frontend/app.jsx
@@ -380,6 +380,7 @@ async function boot() {
   root.render(
     <I18nProvider>
       <AuthRoot />
+      <DemoRibbon />
     </I18nProvider>
   );
 }

--- a/frontend/components/app-shell.jsx
+++ b/frontend/components/app-shell.jsx
@@ -253,6 +253,36 @@ function Topbar({ crumbs, actions, theme, onToggleTheme }) {
   );
 }
 
+// Corner ribbon shown when the backend runs with DEMO_MODE=1 (demo instance).
+// Rendered at the app root so it covers every screen, login included.
+// pointer-events:none — purely visual, never intercepts clicks; the band is
+// placed so it doesn't visually cover the topbar controls in the corner.
+function DemoRibbon() {
+  const [demo, setDemo] = useState(false);
+  useEffect(() => {
+    fetch("/api/config")
+      .then(r => (r.ok ? r.json() : {}))
+      .then(c => setDemo(!!c.demo_mode))
+      .catch(() => {});
+  }, []);
+  if (!demo) return null;
+  return (
+    <div aria-hidden="true" style={{position:"fixed", top:0, right:0, width:120, height:120, overflow:"hidden", pointerEvents:"none", zIndex:5000}}>
+      <div style={{
+        position:"absolute", top:30, right:-34, transform:"rotate(45deg)",
+        background:"var(--warn, #f59e0b)", color:"#1a1208",
+        fontSize:11, fontWeight:700, letterSpacing:"0.18em", textTransform:"uppercase",
+        textAlign:"center", padding:"4px 40px",
+        boxShadow:"0 2px 8px rgba(0,0,0,0.35)",
+        fontFamily:"var(--font-mono, monospace)",
+      }}>
+        Demo
+      </div>
+    </div>
+  );
+}
+
 window.Sidebar = Sidebar;
 window.Topbar = Topbar;
 window.NAV = NAV_CONFIG;
+window.DemoRibbon = DemoRibbon;


### PR DESCRIPTION
## What

When the backend runs with `DEMO_MODE=1` (the demo VPS), the UI shows a fixed "Demo" corner ribbon in the top-right, on every screen including login.

- **Never blocks usage**: `pointer-events: none` — clicks pass straight through; verified via `document.elementFromPoint` under the ribbon area. Positioned so it doesn't visually cover the corner controls either.
- New public `GET /api/config` endpoint returning `{"demo_mode": bool}` — unauthenticated on purpose (the login screen needs it), booleans only, no version/secrets (unlike `/api/about`, which stays auth-gated).
- `DemoRibbon` rendered at the React root next to `AuthRoot`, so it survives login/logout/2FA screens.

## Testing

- 3 new backend tests (flag off/on, endpoint is public and minimal); full suite 654 passed, 1 skipped.
- Playwright drive with `DEMO_MODE=1`: ribbon on login, ribbon in app, login flow unaffected, click-through verified — 4/4.
- Without `DEMO_MODE` the component renders nothing and the fetch is a single boot-time call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)