### PR TITLE
fix(security): auth on webhooks + integrations, block SSRF and path traversal

### DIFF
--- a/backend/net_guard.py
+++ b/backend/net_guard.py
@@ -1,0 +1,69 @@
+"""SSRF egress guard for user/admin-supplied outbound URLs (webhooks, etc.).
+
+`assert_public_http_url` rejects a URL whose host resolves to a private,
+loopback, link-local, reserved, or otherwise non-public address — the classic
+SSRF pivots (cloud metadata at 169.254.169.254, localhost services, RFC-1918
+internal hosts). It resolves the hostname and checks *every* returned address,
+so a public name that resolves to an internal IP (DNS-rebinding style) is also
+blocked.
+
+Set WEBHOOK_ALLOW_PRIVATE_HOSTS=1 to disable the IP checks — needed for local
+dev and the e2e suite, which point webhooks at 127.0.0.1. Never set it in
+production.
+"""
+import ipaddress
+import os
+import socket
+from urllib.parse import urlparse
+
+
+class UnsafeURLError(ValueError):
+    """Raised when a URL is not safe to call (bad scheme or non-public host)."""
+
+
+def _guard_disabled() -> bool:
+    return os.getenv("WEBHOOK_ALLOW_PRIVATE_HOSTS", "").strip().lower() in ("1", "true", "yes")
+
+
+def _ip_is_blocked(ip: str) -> bool:
+    try:
+        addr = ipaddress.ip_address(ip)
+    except ValueError:
+        return True  # unparseable — refuse
+    # IPv4-mapped IPv6 (::ffff:a.b.c.d) — unwrap to judge the real target.
+    if isinstance(addr, ipaddress.IPv6Address) and addr.ipv4_mapped is not None:
+        addr = addr.ipv4_mapped
+    return (
+        addr.is_private
+        or addr.is_loopback
+        or addr.is_link_local
+        or addr.is_reserved
+        or addr.is_multicast
+        or addr.is_unspecified
+    )
+
+
+def assert_public_http_url(url: str) -> None:
+    """Raise UnsafeURLError unless `url` is an http(s) URL whose host resolves
+    only to public addresses. A no-op when WEBHOOK_ALLOW_PRIVATE_HOSTS is set."""
+    parsed = urlparse((url or "").strip())
+    if parsed.scheme not in ("http", "https"):
+        raise UnsafeURLError("URL must use http or https")
+    host = parsed.hostname
+    if not host:
+        raise UnsafeURLError("URL has no host")
+
+    if _guard_disabled():
+        return
+
+    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    try:
+        infos = socket.getaddrinfo(host, port, proto=socket.IPPROTO_TCP)
+    except socket.gaierror:
+        raise UnsafeURLError(f"cannot resolve host: {host}")
+    if not infos:
+        raise UnsafeURLError(f"cannot resolve host: {host}")
+    for info in infos:
+        ip = info[4][0]
+        if _ip_is_blocked(ip):
+            raise UnsafeURLError(f"host {host} resolves to a non-public address ({ip})")

--- a/backend/notifications.py
+++ b/backend/notifications.py
@@ -13,6 +13,7 @@ from . import emailer
 from .db import SessionLocal
 from . import models
 from .webhook_utils import sign_payload
+from .net_guard import assert_public_http_url, UnsafeURLError
 
 # @mention tokens: an @ followed by a username-ish run (letters, digits, _ . -).
 _MENTION_RE = re.compile(r"@([A-Za-z0-9_][A-Za-z0-9_.\-]*)")
@@ -201,9 +202,13 @@ async def _fire_webhooks(run_id: str):
                 headers["X-Hub-Signature-256"] = sign_payload(body_bytes, wh.hmac_secret)
             status_code = 0
             try:
+                # SSRF guard at delivery time — never POST to an internal host.
+                assert_public_http_url(wh.url)
                 async with httpx.AsyncClient(timeout=5.0) as client:
                     r = await client.post(wh.url, content=body_bytes, headers=headers)
                     status_code = r.status_code
+            except UnsafeURLError:
+                status_code = 0
             except Exception:
                 status_code = 0
             wh.last_status_code = status_code

--- a/backend/routers/attachments.py
+++ b/backend/routers/attachments.py
@@ -15,9 +15,21 @@ from ..auth_utils import get_current_user, require_role
 UPLOAD_DIR = os.getenv("UPLOAD_DIR", "./uploads")
 MAX_UPLOAD_MB = int(os.getenv("MAX_UPLOAD_MB", "50"))
 
+# Entity types an attachment may be bound to. Restricting this also constrains
+# the on-disk directory name, closing the path-traversal vector below.
+ALLOWED_ENTITY_TYPES = {"test", "step", "run_case"}
+
 router = APIRouter(tags=["attachments"])
 
 WRITE_ROLES = require_role("admin", "manager", "tester")
+
+
+def _safe_component(value: str) -> str:
+    """Reject any value that could escape UPLOAD_DIR when used as a path part."""
+    value = (value or "").strip()
+    if not value or "/" in value or "\\" in value or value in (".", "..") or "\x00" in value:
+        raise HTTPException(status_code=422, detail="Invalid path component")
+    return value
 
 
 @router.get("/attachments", response_model=List[AttachmentOut])
@@ -45,6 +57,11 @@ async def upload_attachment(
     db: Session = Depends(get_db),
     _: models.User = WRITE_ROLES,
 ):
+    if entity_type not in ALLOWED_ENTITY_TYPES:
+        raise HTTPException(status_code=422, detail="Invalid entity_type")
+    # entity_id and the stored filename must not be able to walk out of UPLOAD_DIR.
+    safe_entity_id = _safe_component(str(entity_id))
+
     content = await file.read()  # read stream ONCE
     size_mb = len(content) / (1024 * 1024)
     if size_mb > MAX_UPLOAD_MB:
@@ -53,14 +70,22 @@ async def upload_attachment(
             detail=f"File exceeds {MAX_UPLOAD_MB}MB limit",
         )
 
-    # Store relative path — safe for Docker and moves
-    rel_dir = os.path.join(entity_type, str(entity_id))
+    # Store relative path — safe for Docker and moves. The on-disk name is a
+    # random UUID plus only the client filename's *basename*, so a filename like
+    # "../../etc/passwd" can't traverse; the original name is kept in the DB.
+    rel_dir = os.path.join(entity_type, safe_entity_id)
     abs_dir = os.path.join(UPLOAD_DIR, rel_dir)
     os.makedirs(abs_dir, exist_ok=True)
 
-    safe_filename = f"{uuid.uuid4().hex}_{file.filename}"
+    client_basename = os.path.basename(file.filename or "")
+    safe_filename = f"{uuid.uuid4().hex}_{client_basename}"
     rel_path = os.path.join(rel_dir, safe_filename)
     abs_path = os.path.join(UPLOAD_DIR, rel_path)
+
+    # Defense in depth: refuse if the resolved path escapes UPLOAD_DIR.
+    upload_root = os.path.realpath(UPLOAD_DIR)
+    if os.path.commonpath([upload_root, os.path.realpath(abs_path)]) != upload_root:
+        raise HTTPException(status_code=422, detail="Invalid attachment path")
 
     async with aiofiles.open(abs_path, "wb") as f:
         await f.write(content)
@@ -84,7 +109,10 @@ def download_attachment(att_id: int, db: Session = Depends(get_db), current_user
     att = db.query(models.Attachment).filter(models.Attachment.id == att_id).first()
     if not att:
         raise HTTPException(status_code=404, detail="Attachment not found")
-    abs_path = os.path.join(UPLOAD_DIR, att.storage_path)
+    upload_root = os.path.realpath(UPLOAD_DIR)
+    abs_path = os.path.realpath(os.path.join(UPLOAD_DIR, att.storage_path))
+    if os.path.commonpath([upload_root, abs_path]) != upload_root:
+        raise HTTPException(status_code=404, detail="File not found on disk")
     if not os.path.exists(abs_path):
         raise HTTPException(status_code=404, detail="File not found on disk")
     return FileResponse(

--- a/backend/routers/integrations.py
+++ b/backend/routers/integrations.py
@@ -21,7 +21,7 @@ def list_integrations(db: Session = Depends(get_db), _: models.User = Depends(ge
 
 
 @router.post("/integrations", response_model=IntegrationOut, status_code=201)
-def create_integration(payload: IntegrationCreate, db: Session = Depends(get_db)):
+def create_integration(payload: IntegrationCreate, db: Session = Depends(get_db), _: models.User = WRITE_ROLES):
     existing = db.query(models.Integration).filter(models.Integration.id == payload.id).first()
     if existing:
         raise HTTPException(status_code=409, detail="Integration ID already exists")
@@ -33,7 +33,7 @@ def create_integration(payload: IntegrationCreate, db: Session = Depends(get_db)
 
 
 @router.patch("/integrations/{intg_id}", response_model=IntegrationOut)
-def update_integration(intg_id: str, payload: IntegrationUpdate, db: Session = Depends(get_db)):
+def update_integration(intg_id: str, payload: IntegrationUpdate, db: Session = Depends(get_db), _: models.User = WRITE_ROLES):
     intg = db.query(models.Integration).filter(models.Integration.id == intg_id).first()
     if not intg:
         raise HTTPException(status_code=404, detail="Integration not found")
@@ -85,7 +85,7 @@ def sync_integration_now(intg_id: str, db: Session = Depends(get_db), _: models.
 
 
 @router.delete("/integrations/{intg_id}", status_code=204)
-def delete_integration(intg_id: str, db: Session = Depends(get_db)):
+def delete_integration(intg_id: str, db: Session = Depends(get_db), _: models.User = WRITE_ROLES):
     intg = db.query(models.Integration).filter(models.Integration.id == intg_id).first()
     if not intg:
         raise HTTPException(status_code=404, detail="Integration not found")

--- a/backend/routers/webhooks.py
+++ b/backend/routers/webhooks.py
@@ -8,17 +8,32 @@ from ..db import get_db
 from .. import models
 from ..schemas import WebhookOut, WebhookCreate, WebhookUpdate, WebhookCreated
 from ..webhook_utils import generate_secret, sign_payload
+from ..net_guard import assert_public_http_url, UnsafeURLError
+from ..auth_utils import get_current_user, require_role
 
 router = APIRouter(tags=["webhooks"])
 
+# Managing outbound webhooks (which cause the server to make requests to
+# arbitrary URLs) is an admin/manager operation.
+WRITE_ROLES = require_role("admin", "manager")
+
+
+def _validate_target(url: str) -> None:
+    """Reject webhook targets that would let the server reach internal hosts."""
+    try:
+        assert_public_http_url(url)
+    except UnsafeURLError as e:
+        raise HTTPException(status_code=422, detail=f"Unsafe webhook URL: {e}")
+
 
 @router.get("/webhooks", response_model=List[WebhookOut])
-def list_webhooks(db: Session = Depends(get_db)):
+def list_webhooks(db: Session = Depends(get_db), _: models.User = Depends(get_current_user)):
     return db.query(models.Webhook).all()
 
 
 @router.post("/webhooks", response_model=WebhookCreated, status_code=201)
-def create_webhook(payload: WebhookCreate, db: Session = Depends(get_db)):
+def create_webhook(payload: WebhookCreate, db: Session = Depends(get_db), _: models.User = WRITE_ROLES):
+    _validate_target(payload.url)
     secret = generate_secret()
     wh = models.Webhook(url=payload.url, events=payload.events, hmac_secret=secret)
     db.add(wh)
@@ -32,11 +47,14 @@ def create_webhook(payload: WebhookCreate, db: Session = Depends(get_db)):
 
 
 @router.patch("/webhooks/{wh_id}", response_model=WebhookOut)
-def update_webhook(wh_id: int, payload: WebhookUpdate, db: Session = Depends(get_db)):
+def update_webhook(wh_id: int, payload: WebhookUpdate, db: Session = Depends(get_db), _: models.User = WRITE_ROLES):
     wh = db.query(models.Webhook).filter(models.Webhook.id == wh_id).first()
     if not wh:
         raise HTTPException(status_code=404, detail="Webhook not found")
-    for field, value in payload.model_dump(exclude_unset=True).items():
+    updates = payload.model_dump(exclude_unset=True)
+    if updates.get("url"):
+        _validate_target(updates["url"])
+    for field, value in updates.items():
         setattr(wh, field, value)
     db.commit()
     db.refresh(wh)
@@ -44,7 +62,7 @@ def update_webhook(wh_id: int, payload: WebhookUpdate, db: Session = Depends(get
 
 
 @router.delete("/webhooks/{wh_id}", status_code=204)
-def delete_webhook(wh_id: int, db: Session = Depends(get_db)):
+def delete_webhook(wh_id: int, db: Session = Depends(get_db), _: models.User = WRITE_ROLES):
     wh = db.query(models.Webhook).filter(models.Webhook.id == wh_id).first()
     if not wh:
         raise HTTPException(status_code=404, detail="Webhook not found")
@@ -53,7 +71,7 @@ def delete_webhook(wh_id: int, db: Session = Depends(get_db)):
 
 
 @router.post("/webhooks/{wh_id}/regenerate-secret", response_model=WebhookCreated)
-def regenerate_webhook_secret(wh_id: int, db: Session = Depends(get_db)):
+def regenerate_webhook_secret(wh_id: int, db: Session = Depends(get_db), _: models.User = WRITE_ROLES):
     wh = db.query(models.Webhook).filter(models.Webhook.id == wh_id).first()
     if not wh:
         raise HTTPException(status_code=404, detail="Webhook not found")
@@ -69,10 +87,13 @@ def regenerate_webhook_secret(wh_id: int, db: Session = Depends(get_db)):
 
 
 @router.post("/webhooks/{wh_id}/test")
-async def test_webhook(wh_id: int, db: Session = Depends(get_db)):
+async def test_webhook(wh_id: int, db: Session = Depends(get_db), _: models.User = WRITE_ROLES):
     wh = db.query(models.Webhook).filter(models.Webhook.id == wh_id).first()
     if not wh:
         raise HTTPException(status_code=404, detail="Webhook not found")
+    # Re-validate at delivery time: a stored URL could pre-date the guard, or a
+    # host could have been re-pointed at an internal address since it was saved.
+    _validate_target(wh.url)
     payload = {
         "event": "test",
         "source": "thorotest",

--- a/backend/tests/test_authz_p0.py
+++ b/backend/tests/test_authz_p0.py
@@ -1,0 +1,162 @@
+"""Regression tests for the P0 access-control fixes (2026-07 security audit).
+
+Guards against the class of bug where a state-changing endpoint ships without an
+auth dependency. Covers:
+  - Webhooks CRUD + secret-regen + test → require authentication and admin/manager.
+  - Integrations create/update/delete → require authentication and admin/manager.
+  - SSRF guard rejects webhook targets that resolve to internal addresses.
+  - Attachment upload cannot be used to traverse outside UPLOAD_DIR.
+
+If any of these routes ever loses its dependency again, these tests fail.
+"""
+import io
+import os
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.main import app
+from backend.db import get_db
+from backend import models
+from backend.auth_utils import hash_password, create_access_token
+
+
+@pytest.fixture
+def anon_client(db):
+    """Unauthenticated TestClient (no Authorization header) sharing the test db."""
+    def override_get_db():
+        yield db
+    app.dependency_overrides[get_db] = override_get_db
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def tester_client(db):
+    """Authenticated TestClient with the low-privilege `tester` role."""
+    user = models.User(
+        username="p0_tester", email="p0tester@test.com",
+        hashed_password=hash_password("pass123"), display_name="P0 Tester", role="tester",
+    )
+    db.add(user)
+    db.flush()
+    token = create_access_token(user.id)
+
+    def override_get_db():
+        yield db
+    app.dependency_overrides[get_db] = override_get_db
+    with TestClient(app, headers={"Authorization": f"Bearer {token}"}) as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+# ── Webhooks: must be authenticated ───────────────────────────────────────────
+
+WEBHOOK_MUTATIONS = [
+    ("post", "/api/webhooks", {"json": {"url": "https://example.com/h", "events": []}}),
+    ("patch", "/api/webhooks/1", {"json": {"status": "paused"}}),
+    ("delete", "/api/webhooks/1", {}),
+    ("post", "/api/webhooks/1/regenerate-secret", {}),
+    ("post", "/api/webhooks/1/test", {}),
+]
+
+
+@pytest.mark.parametrize("method,path,kw", WEBHOOK_MUTATIONS)
+def test_webhook_mutations_reject_anonymous(anon_client, method, path, kw):
+    r = getattr(anon_client, method)(path, **kw)
+    assert r.status_code in (401, 403), f"{method} {path} allowed anonymous access: {r.status_code}"
+
+
+def test_webhook_list_rejects_anonymous(anon_client):
+    assert anon_client.get("/api/webhooks").status_code in (401, 403)
+
+
+@pytest.mark.parametrize("method,path,kw", WEBHOOK_MUTATIONS)
+def test_webhook_mutations_reject_tester(tester_client, method, path, kw):
+    r = getattr(tester_client, method)(path, **kw)
+    # tester is authenticated but not admin/manager → 403 (or 404 only if it got
+    # past auth, which must not happen for a missing id — so require 403).
+    assert r.status_code == 403, f"{method} {path} allowed tester: {r.status_code}"
+
+
+# ── Integrations: create/update/delete must be authenticated admin/manager ────
+
+INTEGRATION_MUTATIONS = [
+    ("post", "/api/integrations", {"json": {"id": "i1", "name": "x", "type": "github"}}),
+    ("patch", "/api/integrations/i1", {"json": {"name": "y"}}),
+    ("delete", "/api/integrations/i1", {}),
+]
+
+
+@pytest.mark.parametrize("method,path,kw", INTEGRATION_MUTATIONS)
+def test_integration_mutations_reject_anonymous(anon_client, method, path, kw):
+    r = getattr(anon_client, method)(path, **kw)
+    assert r.status_code in (401, 403), f"{method} {path} allowed anonymous: {r.status_code}"
+
+
+@pytest.mark.parametrize("method,path,kw", INTEGRATION_MUTATIONS)
+def test_integration_mutations_reject_tester(tester_client, method, path, kw):
+    r = getattr(tester_client, method)(path, **kw)
+    assert r.status_code == 403, f"{method} {path} allowed tester: {r.status_code}"
+
+
+# ── SSRF guard on webhook targets ─────────────────────────────────────────────
+
+@pytest.mark.parametrize("bad_url", [
+    "http://127.0.0.1/hook",
+    "http://localhost/hook",
+    "http://169.254.169.254/latest/meta-data/",
+    "http://10.0.0.5/x",
+    "http://192.168.1.1/x",
+    "ftp://example.com/x",
+    "file:///etc/passwd",
+])
+def test_create_webhook_rejects_unsafe_url(client, monkeypatch, bad_url):
+    # Ensure the guard is active regardless of ambient env.
+    monkeypatch.delenv("WEBHOOK_ALLOW_PRIVATE_HOSTS", raising=False)
+    r = client.post("/api/webhooks", json={"url": bad_url, "events": ["run.completed"]})
+    assert r.status_code == 422, f"unsafe url {bad_url} was accepted: {r.status_code} {r.text}"
+
+
+def test_create_webhook_allows_public_url(client, monkeypatch):
+    monkeypatch.delenv("WEBHOOK_ALLOW_PRIVATE_HOSTS", raising=False)
+    r = client.post("/api/webhooks", json={"url": "https://example.com/hook", "events": []})
+    assert r.status_code == 201, r.text
+
+
+# ── Attachment path traversal ─────────────────────────────────────────────────
+
+def _file(content=b"x", filename="a.txt"):
+    return ("file", (filename, io.BytesIO(content), "text/plain"))
+
+
+def test_upload_rejects_bad_entity_type(client, tmp_path, monkeypatch):
+    import backend.routers.attachments as att
+    monkeypatch.setattr(att, "UPLOAD_DIR", str(tmp_path))
+    r = client.post("/api/attachments",
+                    data={"entity_type": "../../etc", "entity_id": "1"}, files=[_file()])
+    assert r.status_code == 422
+
+
+def test_upload_rejects_traversal_entity_id(client, tmp_path, monkeypatch):
+    import backend.routers.attachments as att
+    monkeypatch.setattr(att, "UPLOAD_DIR", str(tmp_path))
+    r = client.post("/api/attachments",
+                    data={"entity_type": "test", "entity_id": "../../../evil"}, files=[_file()])
+    assert r.status_code == 422
+
+
+def test_upload_neutralizes_traversal_filename(client, tmp_path, monkeypatch):
+    import backend.routers.attachments as att
+    monkeypatch.setattr(att, "UPLOAD_DIR", str(tmp_path))
+    r = client.post("/api/attachments",
+                    data={"entity_type": "test", "entity_id": "TC-1"},
+                    files=[_file(content=b"pwned", filename="../../../../tmp/evil.txt")])
+    assert r.status_code == 201, r.text
+    # Nothing may have been written outside UPLOAD_DIR.
+    written = [os.path.join(root, f) for root, _, fs in os.walk(str(tmp_path)) for f in fs]
+    assert written, "file should have been stored inside UPLOAD_DIR"
+    for p in written:
+        assert os.path.realpath(p).startswith(os.path.realpath(str(tmp_path)))
+        assert "evil.txt" in os.path.basename(p)  # basename kept, path stripped

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -36,6 +36,9 @@ export default defineConfig({
     env: {
       DATABASE_URL: 'sqlite:///./e2e.db',
       LOGIN_RATELIMIT_DISABLED: '1',
+      // e2e webhook tests point at a local target; allow private hosts for the
+      // SSRF guard in this environment only (never in production).
+      WEBHOOK_ALLOW_PRIVATE_HOSTS: '1',
       PYTHONUNBUFFERED: '1',
     },
   },


### PR DESCRIPTION
## What

Closes the P0 access-control findings from the 2026-07 security audit. Two clusters of state-changing endpoints shipped **without any auth dependency**, and there is no global auth middleware to catch the omission.

### Fixes
- **Webhooks** (`list`/`create`/`update`/`delete`/`regenerate-secret`/`test`) were fully unauthenticated. An anonymous caller could enumerate delivery URLs, obtain the HMAC signing secret, rotate it, and (via `/test`) make the server POST to any URL — a **blind SSRF**. Now `get_current_user` + `require_role(admin, manager)`.
- **Integrations** `create`/`update`/`delete` were unauthenticated, exposing the config blob (git PAT / Jira token) to anonymous modification and token retargeting. Now `require_role(admin, manager)` (`sync` already was).
- **SSRF egress guard** (`backend/net_guard.py`): resolves a webhook target and refuses private/loopback/link-local/reserved/metadata addresses. Applied at create/update, at `/test`, and at delivery time in `_fire_webhooks`. Escape hatch `WEBHOOK_ALLOW_PRIVATE_HOSTS=1` for local dev + e2e only.
- **Attachment path traversal**: restrict `entity_type` to a whitelist, reject `entity_id` with path separators, store only the client filename's basename, assert the resolved path stays inside `UPLOAD_DIR` (upload + download).

### Tests
- New `backend/tests/test_authz_p0.py` (28 cases): anonymous **and** tester-role requests to every previously-unauthenticated mutation must `401`/`403`; SSRF guard rejects internal targets and accepts public ones; attachment upload cannot escape `UPLOAD_DIR`.
- Full backend suite: **682 passed, 1 skipped**.

## Reviewer notes
- Rotate the Anthropic API key separately (audit H-3) — not in this PR.
- `playwright.config.ts` sets `WEBHOOK_ALLOW_PRIVATE_HOSTS=1` so e2e webhook tests can target localhost.
- ⚠️ The `ci/deploy-demo` workflow auto-deploys any `v*` tag to the public demo VPS — merge this before tagging a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)