### PR TITLE
feat(demo): demo-account logins on the login screen under DEMO_MODE

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -232,16 +232,33 @@ app.add_middleware(
 _STARTED_AT = time.monotonic()
 
 
+# Demo accounts advertised on the login screen when DEMO_MODE is on. These
+# mirror the throwaway users created by backend.seed (seed_db) — never real
+# credentials. Exposed ONLY under DEMO_MODE, which the app refuses to run with
+# ENVIRONMENT=production, so these passwords can never surface on a prod deploy.
+DEMO_ACCOUNTS = [
+    {"email": "admin@localhost", "password": "admin", "role": "admin", "display_name": "Admin"},
+    {"email": "marco@acme.com", "password": "demo123", "role": "admin", "display_name": "Marco Rossi"},
+    {"email": "lisa@acme.com", "password": "demo123", "role": "tester", "display_name": "Lisa Park"},
+    {"email": "alex@acme.com", "password": "demo123", "role": "tester", "display_name": "Alex Rivera"},
+]
+
+
 @app.get("/api/config")
 async def public_config():
     """Public UI bootstrap flags.
 
     Deliberately unauthenticated — the login screen needs them (e.g. the demo
-    ribbon) — and deliberately minimal: booleans only, no version, no secrets.
+    ribbon). Minimal by design: no version, no secrets. `demo_accounts` is only
+    populated under DEMO_MODE (a demo instance), listing the seeded throwaway
+    logins so visitors can sign in; it is an empty list otherwise.
     """
     from .ws_manager import DEMO_MODE  # read at call time so tests can patch it
 
-    return {"demo_mode": DEMO_MODE}
+    return {
+        "demo_mode": DEMO_MODE,
+        "demo_accounts": DEMO_ACCOUNTS if DEMO_MODE else [],
+    }
 
 
 @app.get("/health")

--- a/backend/tests/test_demo_mode.py
+++ b/backend/tests/test_demo_mode.py
@@ -62,16 +62,31 @@ def test_config_demo_mode_off_by_default(client, monkeypatch):
     monkeypatch.setattr(ws_manager, "DEMO_MODE", False)
     r = client.get("/api/config")
     assert r.status_code == 200
-    assert r.json() == {"demo_mode": False}
+    assert r.json() == {"demo_mode": False, "demo_accounts": []}
 
 
 def test_config_demo_mode_on(client, monkeypatch):
     monkeypatch.setattr(ws_manager, "DEMO_MODE", True)
-    assert client.get("/api/config").json() == {"demo_mode": True}
+    body = client.get("/api/config").json()
+    assert body["demo_mode"] is True
+    assert len(body["demo_accounts"]) >= 1
+
+
+def test_demo_accounts_only_exposed_under_demo_mode(client, monkeypatch):
+    """Seeded demo logins must never be advertised on a normal deploy."""
+    monkeypatch.setattr(ws_manager, "DEMO_MODE", False)
+    assert client.get("/api/config").json()["demo_accounts"] == []
+
+    monkeypatch.setattr(ws_manager, "DEMO_MODE", True)
+    accounts = client.get("/api/config").json()["demo_accounts"]
+    assert accounts, "demo_accounts must be populated under DEMO_MODE"
+    for acct in accounts:
+        assert set(acct.keys()) == {"email", "password", "role", "display_name"}
+        assert acct["role"] in ("admin", "manager", "tester")
 
 
 def test_config_is_public_and_minimal(db, monkeypatch):
-    """No auth required (login screen needs it), and nothing but the flag."""
+    """No auth required (login screen needs it), and only the documented keys."""
     from fastapi.testclient import TestClient
     from backend.main import app
     from backend.db import get_db
@@ -85,4 +100,4 @@ def test_config_is_public_and_minimal(db, monkeypatch):
         r = c.get("/api/config")
     app.dependency_overrides.clear()
     assert r.status_code == 200
-    assert set(r.json().keys()) == {"demo_mode"}
+    assert set(r.json().keys()) == {"demo_mode", "demo_accounts"}

--- a/frontend/views/view-login.jsx
+++ b/frontend/views/view-login.jsx
@@ -12,6 +12,22 @@ function LoginPage({ onLogin, oauthError, onDismissOAuthError }) {
   const [mode, setMode] = useState(resetToken ? "reset" : "login");
   const [newPassword, setNewPassword] = useState("");
   const [resetDone, setResetDone] = useState(false);
+  // Demo instances (DEMO_MODE) advertise seeded throwaway logins so visitors
+  // can sign in; empty on a normal deploy.
+  const [demoAccounts, setDemoAccounts] = useState([]);
+
+  useEffect(() => {
+    fetch("/api/config")
+      .then(r => (r.ok ? r.json() : {}))
+      .then(c => setDemoAccounts(Array.isArray(c.demo_accounts) ? c.demo_accounts : []))
+      .catch(() => {});
+  }, []);
+
+  const fillDemo = (acct) => {
+    setEmail(acct.email);
+    setPassword(acct.password);
+    setError(null);
+  };
 
   const handleForgot = async (e) => {
     e.preventDefault();
@@ -177,6 +193,54 @@ function LoginPage({ onLogin, oauthError, onDismissOAuthError }) {
             Forgot password?
           </button>
         </form>
+        )}
+
+        {mode === "login" && demoAccounts.length > 0 && (
+          <div className="demo-accounts" role="group" aria-label="Demo accounts" style={{
+            marginTop: 16, padding: 12, borderRadius: 10,
+            border: "1px solid var(--warn, #f59e0b)",
+            background: "color-mix(in srgb, var(--warn, #f59e0b) 8%, transparent)",
+          }}>
+            <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 8 }}>
+              <span style={{ fontSize: 11, fontWeight: 700, letterSpacing: "0.12em", textTransform: "uppercase", color: "var(--warn, #f59e0b)" }}>
+                Demo accounts
+              </span>
+              <span style={{ fontSize: 11, color: "var(--text-muted)" }}>— click to sign in</span>
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+              {demoAccounts.map(acct => (
+                <button
+                  key={acct.email}
+                  type="button"
+                  onClick={() => fillDemo(acct)}
+                  title={`Fill ${acct.email}`}
+                  style={{
+                    display: "flex", alignItems: "center", justifyContent: "space-between", gap: 10,
+                    padding: "7px 10px", borderRadius: 8, cursor: "pointer",
+                    border: "1px solid var(--border, #3f3f5a)", background: "var(--surface, #1e1e2e)",
+                    textAlign: "left", width: "100%",
+                  }}
+                >
+                  <span style={{ display: "flex", flexDirection: "column", minWidth: 0 }}>
+                    <span style={{ fontSize: 13, fontWeight: 600, color: "var(--text, #e5e7eb)", overflow: "hidden", textOverflow: "ellipsis" }}>
+                      {acct.email}
+                    </span>
+                    <span style={{ fontSize: 11, color: "var(--text-muted)", fontFamily: "var(--font-mono, monospace)" }}>
+                      {acct.password}
+                    </span>
+                  </span>
+                  <span style={{
+                    flexShrink: 0, fontSize: 10, fontWeight: 700, letterSpacing: "0.06em", textTransform: "uppercase",
+                    padding: "2px 8px", borderRadius: 999,
+                    color: acct.role === "admin" ? "#1a1208" : "var(--text, #e5e7eb)",
+                    background: acct.role === "admin" ? "var(--warn, #f59e0b)" : "var(--border, #3f3f5a)",
+                  }}>
+                    {acct.role}
+                  </span>
+                </button>
+              ))}
+            </div>
+          </div>
         )}
 
         {mode === "login" && (<React.Fragment>


### PR DESCRIPTION
## What

On a demo instance (`DEMO_MODE=1`), the login page shows a **Demo accounts** balloon listing the seeded throwaway logins — email, password, and a role badge. Clicking a row fills the form. Visitors can sign in without being handed credentials out of band.

## How
- `GET /api/config` (already public, already returns `demo_mode`) now also returns `demo_accounts`: the seeded demo logins when `DEMO_MODE` is on, an empty list otherwise. `DEMO_MODE` is refused when `ENVIRONMENT=production`, so these passwords can never surface on a production deploy.
- `frontend/views/view-login.jsx` fetches `/api/config`, and in login mode renders the balloon only when `demo_accounts` is non-empty. Each row is click-to-fill (email + password), with an admin/tester pill.

## Notes
- Accounts mirror `backend.seed` (`admin@localhost`, `marco`/`lisa`/`alex @acme.com`). Run `python -m backend.seed` on the demo box so those users exist — a plain boot seeds only `admin@localhost`.
- Passwords are intentionally shown; these are disposable demo accounts and the endpoint only exposes them under `DEMO_MODE`.

## Tests
- `/api/config` response shape updated; new coverage: `demo_accounts` is empty without `DEMO_MODE` and populated (with `email`/`password`/`role`) under it. Full backend suite green; frontend builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)