### PR TITLE
Quick wins Q-1..Q-3: hot-filter indexes, initial-data N+1, CSV formula injection

### DIFF
--- a/backend/csv_safe.py
+++ b/backend/csv_safe.py
@@ -1,0 +1,21 @@
+"""CSV formula-injection neutralization (SECURITY M-3).
+
+Spreadsheet apps (Excel, Sheets, LibreOffice) execute cells that start with
+= + - @ or a tab/CR as formulas when a CSV is opened. Any cell built from
+user-controlled text (titles, results, names) must be passed through
+neutralize() before being written to an export.
+"""
+
+_FORMULA_TRIGGERS = ("=", "+", "-", "@", "\t", "\r")
+
+
+def neutralize(value) -> str:
+    """Prefix values that a spreadsheet would treat as formulas with `'`.
+
+    Non-string values (numbers, None already handled by callers) pass through
+    str() untouched unless their rendering starts with a trigger character.
+    """
+    s = value if isinstance(value, str) else str(value)
+    if s.startswith(_FORMULA_TRIGGERS):
+        return "'" + s
+    return s

--- a/backend/main.py
+++ b/backend/main.py
@@ -526,16 +526,35 @@ async def initial_data(db: Session = Depends(get_db), _: models.User = Depends(g
         .limit(INITIAL_DATA_CAPS["requirements"])
         .all()
     )
+    # One query for all requirement→test links instead of a lazy-load per
+    # requirement (N+1): fetch (requirement_id, test_id, status) pairs and
+    # aggregate coverage in Python.
+    req_ids = [r.id for r in all_requirements]
+    linked_by_req: dict[str, list[tuple[str, str]]] = {}
+    if req_ids:
+        link_rows = (
+            db.query(
+                models.requirement_tests.c.requirement_id,
+                models.Test.id,
+                models.Test.status,
+            )
+            .join(models.Test, models.Test.id == models.requirement_tests.c.test_id)
+            .filter(models.requirement_tests.c.requirement_id.in_(req_ids))
+            .all()
+        )
+        for rid, tid, tstatus in link_rows:
+            linked_by_req.setdefault(rid, []).append((tid, tstatus))
+
     requirements_out = []
     for r in all_requirements:
-        linked = r.tests
-        passed = sum(1 for t in linked if t.status == "pass")
-        failed = sum(1 for t in linked if t.status == "fail")
+        linked = linked_by_req.get(r.id, [])
+        passed = sum(1 for _, s in linked if s == "pass")
+        failed = sum(1 for _, s in linked if s == "fail")
         requirements_out.append({
             "id": r.id, "title": r.title, "type": r.type, "status": r.status,
             "priority": r.priority, "owner": r.owner,
             "externalKey": r.external_key, "externalUrl": r.external_url,
-            "testIds": [t.id for t in linked],
+            "testIds": [tid for tid, _ in linked],
             "coverage": {
                 "linked": len(linked), "passed": passed, "failed": failed,
                 "untested": len(linked) - passed - failed,

--- a/backend/models.py
+++ b/backend/models.py
@@ -84,6 +84,7 @@ class Test(Base):
 
     __table_args__ = (
         Index("ix_test_external", "external_provider", "external_key"),
+        Index("ix_tests_folder_status", "folder_id", "status"),
     )
 
     folder_rel = relationship("Folder", back_populates="tests")
@@ -123,8 +124,8 @@ class Run(Base):
 class RunCase(Base):
     __tablename__ = "run_cases"
     id = Column(Integer, primary_key=True, autoincrement=True)
-    run_id = Column(String(255), ForeignKey("runs.id"))
-    test_id = Column(String(255), ForeignKey("tests.id"))
+    run_id = Column(String(255), ForeignKey("runs.id"), index=True)
+    test_id = Column(String(255), ForeignKey("tests.id"), index=True)
     status = Column(String(32), default="pending")
 
     actual_result = Column(Text, nullable=True)
@@ -189,6 +190,10 @@ class Defect(Base):
     external_key = Column(String(128), nullable=True)       # e.g. "PROJ-123"
     external_url = Column(String(512), nullable=True)
     custom_fields = Column(JSON, default=dict)   # {def key: value} — keys defined in custom_field_defs
+
+    __table_args__ = (
+        Index("ix_defects_status_severity", "status", "severity"),
+    )
 
     test_rel = relationship("Test", back_populates="defects")
 

--- a/backend/routers/runs.py
+++ b/backend/routers/runs.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone
 from fastapi import APIRouter, Depends, HTTPException, Response
 from sqlalchemy.orm import Session
 from typing import List
+from ..csv_safe import neutralize
 from ..db import get_db
 from .. import models
 from ..schemas import RunOut, RunDetailOut, RunCreate, DefectOut, StepResultOut, StepResultIn, RunCaseAssign, RunCaseUpdate, RunCaseOut
@@ -397,11 +398,11 @@ def export_run(
         writer.writerow(["test_name", "status", "assigned_to", "duration", "actual_result"])
         for c in cases:
             writer.writerow([
-                c.test.title if c.test else c.test_id,
+                neutralize(c.test.title if c.test else c.test_id),
                 c.status,
-                c.assigned_to or "",
-                c.test.duration if c.test else "",
-                c.actual_result or "",
+                neutralize(c.assigned_to or ""),
+                neutralize(c.test.duration if c.test else ""),
+                neutralize(c.actual_result or ""),
             ])
         content = output.getvalue().encode("utf-8-sig")  # BOM for Excel compatibility
         return Response(

--- a/backend/routers/tests.py
+++ b/backend/routers/tests.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, Depends, HTTPException, Response
 from sqlalchemy import or_, cast, String
 from sqlalchemy.orm import Session
 from typing import List, Optional
+from ..csv_safe import neutralize
 from ..db import get_db
 from .. import models
 from ..schemas import TestOut, TestCreate, TestUpdate, BulkAction, DefectOut, CommentOut, CommentCreate, TestStepOut, TestStepIn
@@ -105,8 +106,8 @@ def export_tests(
     writer.writerow(["title", "folder", "priority", "status", "steps_count", "created_at"])
     for t in tests:
         writer.writerow([
-            t.title,
-            t.folder_rel.name if t.folder_rel else "",
+            neutralize(t.title),
+            neutralize(t.folder_rel.name if t.folder_rel else ""),
             t.priority or "",
             t.status or "",
             len(t.steps),

--- a/backend/tests/test_export.py
+++ b/backend/tests/test_export.py
@@ -140,3 +140,35 @@ class TestExportEndpoints:
         tester = auth_client("tester")
         res = tester.get("/api/tests/export?format=pdf")
         assert res.status_code == 400
+
+    # --- CSV formula-injection neutralization (SECURITY M-3) ---
+
+    def test_tests_export_neutralizes_formula_titles(self, auth_client, seeded, db):
+        from backend import models
+        db.add(models.Test(id="TC-EVIL", title='=HYPERLINK("http://evil","x")',
+                           folder_id="checkout", type="manual", status="pending"))
+        db.flush()
+        tester = auth_client("tester")
+        res = tester.get("/api/tests/export?format=csv")
+        assert res.status_code == 200
+        text = res.content.decode("utf-8-sig")
+        evil_line = next(l for l in text.splitlines() if "HYPERLINK" in l)
+        # csv module quotes the cell (it contains a comma); the payload inside
+        # must start with the neutralizing apostrophe, not a raw '='
+        assert "'=HYPERLINK" in evil_line
+        assert not evil_line.startswith("=")
+
+    def test_run_export_neutralizes_formula_cells(self, auth_client, seeded, db):
+        from backend import models
+        db.add(models.Test(id="TC-EVIL2", title="+cmd|' /C calc'!A0",
+                           folder_id="checkout", type="manual", status="pending"))
+        db.add(models.RunCase(run_id="R-TEST", test_id="TC-EVIL2", status="pending",
+                              actual_result="@SUM(1+9)*cmd"))
+        db.flush()
+        tester = auth_client("tester")
+        res = tester.get("/api/runs/R-TEST/export?format=csv")
+        assert res.status_code == 200
+        text = res.content.decode("utf-8-sig")
+        evil_line = next(l for l in text.splitlines() if "cmd|" in l)
+        assert "'+cmd|" in evil_line
+        assert "'@SUM" in evil_line

--- a/migrations/versions/a7c3e9f14b02_perf_hot_filter_indexes.py
+++ b/migrations/versions/a7c3e9f14b02_perf_hot_filter_indexes.py
@@ -1,0 +1,27 @@
+"""Add indexes for hot filters/joins: run_cases, tests, defects (PERF P-7)
+
+Revision ID: a7c3e9f14b02
+Revises: d4f8a1c26e93
+Create Date: 2026-07-17
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = 'a7c3e9f14b02'
+down_revision = 'd4f8a1c26e93'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index('ix_run_cases_run_id', 'run_cases', ['run_id'])
+    op.create_index('ix_run_cases_test_id', 'run_cases', ['test_id'])
+    op.create_index('ix_tests_folder_status', 'tests', ['folder_id', 'status'])
+    op.create_index('ix_defects_status_severity', 'defects', ['status', 'severity'])
+
+
+def downgrade():
+    op.drop_index('ix_defects_status_severity', table_name='defects')
+    op.drop_index('ix_tests_folder_status', table_name='tests')
+    op.drop_index('ix_run_cases_test_id', table_name='run_cases')
+    op.drop_index('ix_run_cases_run_id', table_name='run_cases')


### PR DESCRIPTION
First batch of audit roadmap quick wins (ROADMAP.md §1).

- **Q-1 / PERF P-7** — Alembic revision `a7c3e9f14b02`: indexes on `run_cases(run_id)`, `run_cases(test_id)`, `tests(folder_id, status)`, `defects(status, severity)`; mirrored in model definitions. Verified upgrade + downgrade on a scratch DB.
- **Q-2 / PERF P-1** — `/api/initial-data` requirement coverage no longer lazy-loads `r.tests` per requirement (N+1, up to 500 queries per app load); replaced with a single join over `requirement_tests`. Response payload unchanged.
- **Q-3 / SECURITY M-3** — CSV exports (runs, test library) neutralize formula-injection cells (`= + - @`, tab, CR) via new `backend/csv_safe.py`; regression tests for `=HYPERLINK`, `+cmd|`, `@SUM` payloads.

Full backend suite: **685 passed, 1 skipped**.

Remaining quick wins (Q-4 password policy, Q-5 forced admin password change, Q-6 repo hygiene, Q-7 dep pinning, Q-8 badge drift) to follow in separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)