### PR TITLE
S-8: shared SSRF guard on GitLab/Jira admin-controlled URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![version](https://img.shields.io/badge/version-1.11.0-blue)](package.json)
 [![license](https://img.shields.io/badge/license-MIT%20%2B%20Commons%20Clause-green)](LICENSE)
-[![tests](https://img.shields.io/badge/tests-661%20unit%20%2B%2037%20e2e%20suites-brightgreen)](#tests)
+[![tests](https://img.shields.io/badge/tests-672%20unit%20%2B%2037%20e2e%20suites-brightgreen)](#tests)
 [![backend](https://img.shields.io/badge/backend-FastAPI-009688)](#stack)
 [![frontend](https://img.shields.io/badge/frontend-React%2018-61DAFB)](#stack)
 [![docker](https://img.shields.io/badge/deploy-Docker-2496ED)](#quickstart)
@@ -351,7 +351,7 @@ lives in one place (the run), never in the YAML.
 
 ## Tests
 
-**661 backend unit tests** (pytest) + **37 Playwright e2e suites** covering every major flow — CI-gated.
+**672 backend unit tests** (pytest) + **37 Playwright e2e suites** covering every major flow — CI-gated.
 
 ```bash
 make test        # backend unit tests

--- a/backend/gitlab_sync.py
+++ b/backend/gitlab_sync.py
@@ -13,6 +13,7 @@ import httpx
 
 from . import models  # noqa: F401  (kept for symmetry / future use)
 from .github_sync import sync_repo
+from .net_guard import assert_public_http_url
 
 _YAML_EXT = (".yml", ".yaml")
 
@@ -52,6 +53,9 @@ class GitLabClient:
     """Thin GitLab REST v4 wrapper. Raises RuntimeError on API errors."""
 
     def __init__(self, api_base: str, token: str | None = None, timeout: float = 15.0):
+        # api_base is admin-controlled (self-hosted GitLab) — refuse internal
+        # targets at the last hop so no config path can turn sync into SSRF.
+        assert_public_http_url(api_base)
         headers = {"Accept": "application/json"}
         if token:
             headers["PRIVATE-TOKEN"] = token

--- a/backend/jira_sync.py
+++ b/backend/jira_sync.py
@@ -18,6 +18,7 @@ from datetime import datetime, timezone
 import httpx
 
 from . import models
+from .net_guard import assert_public_http_url
 
 _ISSUE_TYPE_MAP = {
     "epic": "epic",
@@ -74,6 +75,10 @@ class JiraClient:
 
     def __init__(self, base_url: str, email: str, api_token: str, timeout: float = 15.0):
         self.base_url = normalize_base_url(base_url)
+        # base_url is admin-controlled — the https/hostname regex in
+        # normalize_base_url still admits internal hosts and raw IPs, so
+        # refuse non-public targets here (SECURITY M-1).
+        assert_public_http_url(self.base_url)
         self._client = httpx.Client(
             base_url=self.base_url,
             auth=(email, api_token),

--- a/backend/net_guard.py
+++ b/backend/net_guard.py
@@ -1,4 +1,5 @@
-"""SSRF egress guard for user/admin-supplied outbound URLs (webhooks, etc.).
+"""Shared SSRF egress guard for user/admin-supplied outbound URLs (SECURITY
+M-1 / roadmap S-8): webhooks, GitLab self-hosted api_base, Jira base_url.
 
 `assert_public_http_url` rejects a URL whose host resolves to a private,
 loopback, link-local, reserved, or otherwise non-public address — the classic
@@ -7,9 +8,13 @@ internal hosts). It resolves the hostname and checks *every* returned address,
 so a public name that resolves to an internal IP (DNS-rebinding style) is also
 blocked.
 
-Set WEBHOOK_ALLOW_PRIVATE_HOSTS=1 to disable the IP checks — needed for local
-dev and the e2e suite, which point webhooks at 127.0.0.1. Never set it in
-production.
+Set NET_GUARD_ALLOW_PRIVATE_HOSTS=1 (or the legacy WEBHOOK_ALLOW_PRIVATE_HOSTS)
+to disable the IP checks — needed for local dev and the e2e suite, which point
+webhooks and a local GitLab at 127.0.0.1. Never set either in production.
+
+Deliberately NOT guarded: AI_BASE_URL. It is operator-set environment config
+(never writable through the API), and pointing it at a private host is the
+supported local-LLM setup (Ollama, LM Studio, vLLM).
 """
 import ipaddress
 import os
@@ -22,7 +27,10 @@ class UnsafeURLError(ValueError):
 
 
 def _guard_disabled() -> bool:
-    return os.getenv("WEBHOOK_ALLOW_PRIVATE_HOSTS", "").strip().lower() in ("1", "true", "yes")
+    for var in ("NET_GUARD_ALLOW_PRIVATE_HOSTS", "WEBHOOK_ALLOW_PRIVATE_HOSTS"):
+        if os.getenv(var, "").strip().lower() in ("1", "true", "yes"):
+            return True
+    return False
 
 
 def _ip_is_blocked(ip: str) -> bool:
@@ -43,9 +51,15 @@ def _ip_is_blocked(ip: str) -> bool:
     )
 
 
-def assert_public_http_url(url: str) -> None:
-    """Raise UnsafeURLError unless `url` is an http(s) URL whose host resolves
-    only to public addresses. A no-op when WEBHOOK_ALLOW_PRIVATE_HOSTS is set."""
+def assert_public_http_url(url: str, *, resolve: bool = True) -> None:
+    """Raise UnsafeURLError unless `url` is an http(s) URL on a public host.
+    A no-op when NET_GUARD_ALLOW_PRIVATE_HOSTS is set.
+
+    With resolve=False only the scheme and literal-IP hosts are judged — no
+    DNS lookup. Use it for save-time validation (fail fast without a network
+    dependency); the outbound clients re-check with full resolution at use
+    time, which also covers hostnames that point at internal addresses.
+    """
     parsed = urlparse((url or "").strip())
     if parsed.scheme not in ("http", "https"):
         raise UnsafeURLError("URL must use http or https")
@@ -54,6 +68,20 @@ def assert_public_http_url(url: str) -> None:
         raise UnsafeURLError("URL has no host")
 
     if _guard_disabled():
+        return
+
+    if host.lower() == "localhost" or host.lower().endswith(".localhost"):
+        raise UnsafeURLError("host localhost is not allowed")
+
+    try:
+        ipaddress.ip_address(host)
+    except ValueError:
+        pass  # hostname, not a literal IP
+    else:
+        if _ip_is_blocked(host):
+            raise UnsafeURLError(f"host {host} is a non-public address")
+
+    if not resolve:
         return
 
     port = parsed.port or (443 if parsed.scheme == "https" else 80)

--- a/backend/routers/integrations.py
+++ b/backend/routers/integrations.py
@@ -6,13 +6,39 @@ from .. import models
 from ..schemas import IntegrationOut, IntegrationCreate, IntegrationUpdate
 from ..auth_utils import require_role, get_current_user
 from ..github_sync import sync_integration
-from ..gitlab_sync import sync_integration as sync_gitlab_integration
-from ..jira_sync import sync_jira_requirements
+from ..gitlab_sync import sync_integration as sync_gitlab_integration, parse_gitlab_repo
+from ..jira_sync import sync_jira_requirements, normalize_base_url
+from ..net_guard import assert_public_http_url, UnsafeURLError
 from ..vcs import detect_provider
 
 router = APIRouter(tags=["integrations"])
 
 WRITE_ROLES = require_role("admin", "manager")
+
+
+def _assert_safe_outbound_urls(intg_type: str, config: dict) -> None:
+    """Fail fast (422) when a config points outbound HTTP at a non-public host
+    (SECURITY M-1 / roadmap S-8). The sync/push clients re-check at use time;
+    this surfaces the error at save instead of at the next sync.
+
+    GitHub needs no check: its client always calls the fixed api.github.com.
+    """
+    config = config or {}
+    try:
+        if intg_type == "jira":
+            if config.get("base_url"):
+                assert_public_http_url(normalize_base_url(config["base_url"]), resolve=False)
+        elif config.get("repo_url") or config.get("api_base"):
+            try:
+                provider = detect_provider(config)
+            except ValueError:
+                return  # provider undetectable — sync will reject with its own error
+            if provider == "gitlab":
+                api_base, _ = parse_gitlab_repo(config.get("repo_url") or "",
+                                                config.get("api_base"))
+                assert_public_http_url(api_base, resolve=False)
+    except (UnsafeURLError, ValueError) as e:
+        raise HTTPException(status_code=422, detail=f"Unsafe integration URL: {e}")
 
 
 @router.get("/integrations", response_model=List[IntegrationOut])
@@ -25,6 +51,7 @@ def create_integration(payload: IntegrationCreate, db: Session = Depends(get_db)
     existing = db.query(models.Integration).filter(models.Integration.id == payload.id).first()
     if existing:
         raise HTTPException(status_code=409, detail="Integration ID already exists")
+    _assert_safe_outbound_urls(payload.type, payload.config or {})
     intg = models.Integration(**payload.model_dump())
     db.add(intg)
     db.commit()
@@ -53,6 +80,7 @@ def update_integration(intg_id: str, payload: IntegrationUpdate, db: Session = D
                     merged.pop(secret_key, None)
         merged.pop("token_set", None)
         merged.pop("api_token_set", None)
+        _assert_safe_outbound_urls(updates.get("type") or intg.type, merged)
         intg.config = merged
     for field, value in updates.items():
         setattr(intg, field, value)

--- a/backend/tests/test_gitlab_e2e_integration.py
+++ b/backend/tests/test_gitlab_e2e_integration.py
@@ -52,6 +52,10 @@ if not (TOKEN and _gitlab_up()):
         allow_module_level=True,
     )
 
+# Only reached when the live suite actually runs: it talks to a GitLab on
+# localhost by design, so lift the SSRF egress guard for this process.
+os.environ.setdefault("NET_GUARD_ALLOW_PRIVATE_HOSTS", "1")
+
 pytestmark = pytest.mark.integration
 
 

--- a/backend/tests/test_ssrf_shared_guard.py
+++ b/backend/tests/test_ssrf_shared_guard.py
@@ -1,0 +1,107 @@
+"""S-8 (SECURITY M-1): shared SSRF guard on admin-controlled outbound URLs —
+GitLab self-hosted api_base and Jira base_url, checked fail-fast at
+integration save (no DNS) and with full resolution in the HTTP clients."""
+import socket
+
+import pytest
+
+from backend.net_guard import assert_public_http_url, UnsafeURLError
+
+
+class TestGuardResolveModes:
+    def test_literal_private_ip_blocked_without_dns(self, monkeypatch):
+        def boom(*a, **k):
+            raise AssertionError("DNS lookup attempted in resolve=False mode")
+        monkeypatch.setattr(socket, "getaddrinfo", boom)
+        with pytest.raises(UnsafeURLError):
+            assert_public_http_url("http://169.254.169.254/latest/meta-data", resolve=False)
+        with pytest.raises(UnsafeURLError):
+            assert_public_http_url("https://10.0.0.5/api/v4", resolve=False)
+
+    def test_localhost_hostname_blocked_without_dns(self, monkeypatch):
+        monkeypatch.setattr(socket, "getaddrinfo", lambda *a, **k: [])
+        with pytest.raises(UnsafeURLError):
+            assert_public_http_url("http://localhost:8929/api/v4", resolve=False)
+        with pytest.raises(UnsafeURLError):
+            assert_public_http_url("http://evil.localhost/x", resolve=False)
+
+    def test_public_hostname_passes_without_dns(self, monkeypatch):
+        def boom(*a, **k):
+            raise AssertionError("DNS lookup attempted in resolve=False mode")
+        monkeypatch.setattr(socket, "getaddrinfo", boom)
+        assert_public_http_url("https://acme.atlassian.net", resolve=False)  # no raise
+
+    def test_resolve_mode_blocks_internal_resolution(self, monkeypatch):
+        monkeypatch.setattr(
+            socket, "getaddrinfo",
+            lambda *a, **k: [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("192.168.1.10", 443))],
+        )
+        with pytest.raises(UnsafeURLError):
+            assert_public_http_url("https://internal-gitlab.corp")
+
+    def test_escape_env_disables(self, monkeypatch):
+        monkeypatch.setenv("NET_GUARD_ALLOW_PRIVATE_HOSTS", "1")
+        assert_public_http_url("http://127.0.0.1:8929/api/v4")  # no raise
+
+
+class TestClientConstructorsGuarded:
+    def test_gitlab_client_refuses_private_api_base(self, monkeypatch):
+        monkeypatch.delenv("NET_GUARD_ALLOW_PRIVATE_HOSTS", raising=False)
+        monkeypatch.delenv("WEBHOOK_ALLOW_PRIVATE_HOSTS", raising=False)
+        from backend.gitlab_sync import GitLabClient
+        with pytest.raises(UnsafeURLError):
+            GitLabClient("http://127.0.0.1:8929/api/v4")
+
+    def test_jira_client_refuses_private_base_url(self, monkeypatch):
+        monkeypatch.delenv("NET_GUARD_ALLOW_PRIVATE_HOSTS", raising=False)
+        monkeypatch.delenv("WEBHOOK_ALLOW_PRIVATE_HOSTS", raising=False)
+        from backend.jira_sync import JiraClient
+        with pytest.raises(UnsafeURLError):
+            JiraClient("https://10.1.2.3", "e@e.com", "tok")
+
+
+class TestIntegrationSaveValidation:
+    def test_create_jira_with_private_ip_rejected(self, client):
+        r = client.post("/api/integrations", json={
+            "id": "int-evil-jira", "name": "Jira", "type": "jira",
+            "config": {"base_url": "https://10.0.0.5", "email": "e@e.com",
+                       "api_token": "t", "project_key": "X"},
+        })
+        assert r.status_code == 422
+        assert "Unsafe integration URL" in r.json()["detail"]
+
+    def test_create_gitlab_with_metadata_api_base_rejected(self, client):
+        r = client.post("/api/integrations", json={
+            "id": "int-evil-gl", "name": "GL", "type": "vcs",
+            "config": {"provider": "gitlab",
+                       "repo_url": "https://gitlab.com/acme/web",
+                       "api_base": "http://169.254.169.254/api/v4"},
+        })
+        assert r.status_code == 422
+
+    def test_patch_retarget_to_private_rejected(self, client):
+        r = client.post("/api/integrations", json={
+            "id": "int-gl-ok", "name": "GL", "type": "vcs",
+            "config": {"provider": "gitlab",
+                       "repo_url": "https://gitlab.com/acme/web", "token": "glpat-x"},
+        })
+        assert r.status_code == 201
+        r = client.patch("/api/integrations/int-gl-ok", json={
+            "config": {"provider": "gitlab",
+                       "repo_url": "https://gitlab.com/acme/web",
+                       "api_base": "http://192.168.0.1/api/v4", "token": ""},
+        })
+        assert r.status_code == 422
+
+    def test_create_public_jira_passes_offline(self, client, monkeypatch):
+        # Save-time validation must not do DNS: prove it by making resolution
+        # impossible.
+        def boom(*a, **k):
+            raise AssertionError("DNS lookup attempted at integration save")
+        monkeypatch.setattr(socket, "getaddrinfo", boom)
+        r = client.post("/api/integrations", json={
+            "id": "int-jira-ok", "name": "Jira", "type": "jira",
+            "config": {"base_url": "https://acme.atlassian.net", "email": "e@e.com",
+                       "api_token": "t", "project_key": "PAY"},
+        })
+        assert r.status_code == 201


### PR DESCRIPTION
Closes audit SECURITY M-1 / roadmap S-8 — last open Medium from the security audit's outbound-HTTP cluster.

- `GitLabClient` / `JiraClient` constructors now enforce `assert_public_http_url` with full DNS resolution, covering every sync / push / CI-dispatch path at use time (same defense-in-depth pattern as webhook delivery).
- Integration create/update fail fast (422) on unsafe config URLs via a new `resolve=False` mode: scheme + literal-IP + `localhost` checks with **no DNS lookup**, keeping the unit suite offline-safe; hostnames that resolve to internal IPs are still caught at use time.
- New generic escape env `NET_GUARD_ALLOW_PRIVATE_HOSTS` (legacy `WEBHOOK_ALLOW_PRIVATE_HOSTS` still works). The live-GitLab integration suite lifts the guard only after its skip gate, so normal runs keep it armed.
- **`AI_BASE_URL` deliberately not guarded**: it is env-only (never writable via API since the C-2 fix), and pointing it at a private host is the supported local-LLM setup (Ollama / LM Studio / vLLM). Rationale documented in `net_guard.py`.

11 new tests (guard modes, client constructors, save-time validation incl. offline proof). Full backend suite: **718 passed, 1 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)